### PR TITLE
Add download command cli

### DIFF
--- a/src/snowtool/api/models/downloads.py
+++ b/src/snowtool/api/models/downloads.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import calendar
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import ClassVar, Self
+
+
+@dataclass
+class DownloadResult:
+    status: bool
+    detail: str = ''
+
+
+class BaseUrl(ABC):
+    BASE_DEST: ClassVar[str] = '/d/projects/gisdata/{source}/unprocessed/{import_path}'
+
+    @classmethod
+    def _build_dest(cls, source: str, import_path: str | Path) -> Path:
+        return Path(cls.BASE_DEST.format(source=source, import_path=import_path))
+
+    @classmethod
+    @abstractmethod
+    def _for_date(cls, target_date: date) -> Self:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _iter_downloads(self) -> Iterator[tuple[str, Path]]:
+        raise NotImplementedError
+
+
+@dataclass
+class INSTARRUrls(BaseUrl):
+    urls: dict[str, Path]
+
+    TILES: ClassVar[tuple[str, ...]] = (
+        'h08v04',
+        'h08v05',
+        'h09v04',
+        'h09v05',
+        'h10v04',
+    )
+    BASE_URL: ClassVar[str] = (
+        'ftp://dtn.rc.colorado.edu/shares/snow-today/gridded_data/SPIRES_NRT_V01/{tile}/{year}/SPIRES_NRT_{tile}_MOD09GA061_{year}{month}{day}_V1.0.nc'
+    )
+
+    @classmethod
+    def _for_date(cls, target_date: date) -> INSTARRUrls:
+        tile_downloads = {}
+        for tile in cls.TILES:
+            download_url = cls.BASE_URL.format(
+                tile=tile,
+                year=target_date.year,
+                month=f'{target_date.month:02d}',
+                day=f'{target_date.day}',
+            )
+            dest = cls._build_dest(
+                'instarr',
+                f'{tile}/{target_date.year}/{target_date.month:02d}/',
+            )
+            tile_downloads[download_url] = dest
+        return cls(
+            tile_downloads,
+        )
+
+    def _iter_downloads(self) -> Iterator[tuple[str, Path]]:
+        yield from self.urls.items()
+
+
+@dataclass
+class SWANNUrl(BaseUrl):
+    url: str
+    dest: Path
+
+    BASE_URL: ClassVar[str] = (
+        'https://climate.arizona.edu/data/UA_SWE/DailyData_800m/WY{year}/UA_SWE_Depth_800m_v1_{year}{month}{day}_early.nc'
+    )
+
+    @staticmethod
+    def _water_year(d: date) -> int:
+        """
+        _water_year returns the water year for a given date.
+        Water year N runs from Oct 1 of year (N-1) through Sep 30 of year N.
+
+        Inputs:
+            d: date to check
+        Outputs:
+            Water Year
+        """
+        return d.year + 1 if d.month >= 10 else d.year
+
+    @classmethod
+    def _for_date(cls, target_date: date) -> SWANNUrl:
+        wy = cls._water_year(target_date)
+        download_url = cls.BASE_URL.format(
+            year=wy,
+            month=f'{target_date.month:02d}',
+            day=f'{target_date.day:02d}',
+        )
+        return cls(
+            url=download_url,
+            dest=cls._build_dest('swann', f'{wy!s}/{target_date.month:02d}/'),
+        )
+
+    def _iter_downloads(self) -> Iterator[tuple[str, Path]]:
+        yield self.url, self.dest
+
+
+@dataclass
+class SNODASUrl(BaseUrl):
+    url: str
+    dest: Path
+
+    BASE_URL: ClassVar[str] = (
+        'https://noaadata.apps.nsidc.org/NOAA/G02158/masked/{year}/{month}_{month_abbr}/SNODAS_{year}{month}{day}.tar'
+    )
+    BASE_DEST: ClassVar[str] = '/d/projects/gisdata/snodas/in_db/masked/{import_path}/'
+
+    @classmethod
+    def _for_date(cls, target_date: date) -> SNODASUrl:
+        download_url = cls.BASE_URL.format(
+            year=target_date.year,
+            month=f'{target_date.month:02d}',
+            month_abbr=calendar.month_abbr[target_date.month],
+            day=f'{target_date.day:02d}',
+        )
+        dest = Path(
+            cls.BASE_DEST.format(
+                import_path=f'{target_date.year}/{target_date.month:02d}',
+            ),
+        )
+        return cls(
+            url=download_url,
+            dest=dest,
+        )
+
+    def _iter_downloads(self) -> Iterator[tuple[str, Path]]:
+        yield self.url, self.dest


### PR DESCRIPTION
add-download-command-cli adds the CLI command to download files from data sources for a requested date

### download.py
CLI command script that defines two commands

- **snowtool download date** will download the raw data files from the data sources for the specified date
- **snowtool download retry** will re-attempt any downloads that were identified as missing or failed imports


### downloads.py
Defines the classes for each URL data source and respective methods to build the URL for a requested date

