### PR TITLE
v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Security
 
+## [v0.4.0] - 2026-07-24
+
+### Added
+
+### Changed
+
+- `stats` now requires an explicit variable selection: at least one CLI
+  `--variable` or HTTP `variable` query parameter. The implicit "all
+  variables" default is gone — reading every variable is a multiple of the
+  I/O, so the set is never implicit. A missing `--variable` is a CLI usage
+  error; an absent `variable` query parameter is a 400.
+- Building a multi-variable raster collection now lists each date directory
+  once and resolves every requested variable from that single listing, rather
+  than once per (date, variable) — fewer directory reads over a wide archive,
+  and a missing-variable date fails fast.
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## [v0.3.0] - 2026-07-24
 
 > **Live databases:** no on-disk format changes in this release — existing
@@ -514,7 +536,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release 🎉
 
-[Unreleased]: https://github.com/PSU-CSAR/snowtool/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/PSU-CSAR/snowtool/compare/v0.4.0...HEAD
+[v0.4.0]: https://github.com/PSU-CSAR/snowtool/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/PSU-CSAR/snowtool/compare/v0.2.2...v0.3.0
 [v0.2.2]: https://github.com/PSU-CSAR/snowtool/compare/v0.2.1...v0.2.2
 [v0.2.1]: https://github.com/PSU-CSAR/snowtool/compare/v0.2.0...v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v0.4.0] - 2026-07-24
 
-### Added
-
 ### Changed
 
 - `stats` now requires an explicit variable selection: at least one CLI
@@ -32,12 +30,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   once and resolves every requested variable from that single listing, rather
   than once per (date, variable) — fewer directory reads over a wide archive,
   and a missing-variable date fails fast.
-
-### Removed
-
-### Fixed
-
-### Security
+- `SnowDbReader.zonal_stats` now requires a non-empty `variable_keys`; an empty
+  selection raises `QueryParameterError` instead of silently reading every
+  variable. The "never implicit" rule now holds in the read core, not only at
+  the CLI/HTTP boundaries that also enforce it.
 
 ## [v0.3.0] - 2026-07-24
 

--- a/src/snowtool/api/models/stats.py
+++ b/src/snowtool/api/models/stats.py
@@ -47,8 +47,9 @@ _ZONE_DESC = (
     'variables. Default: whole basin.'
 )
 _VARIABLE_DESC = (
-    'Variable to report (repeatable; default: all). Use a variable key from '
-    'GET /datasets/{dataset}.'
+    'Variable to report (repeatable; at least one required). Use a variable key '
+    'from GET /datasets/{dataset}. Reading every variable is a multiple of the '
+    'I/O, so the set is never implicit.'
 )
 _ALLOW_PARTIAL_DESC = (
     'Permit a basin only partially covered by the dataset grid (default false: a '
@@ -69,7 +70,7 @@ _DATETIME_EXAMPLES = [
 
 class StatsQueryBase(BaseModel):
     zone: list[str] = Field(default_factory=list, description=_ZONE_DESC)
-    variable: list[str] = Field(default_factory=list, description=_VARIABLE_DESC)
+    variable: list[str] = Field(min_length=1, description=_VARIABLE_DESC)
     allow_partial: bool = Field(default=False, description=_ALLOW_PARTIAL_DESC)
     include_empty_zones: bool = Field(default=False, description=_INCLUDE_EMPTY_DESC)
     f: StatsFormat | None = Field(

--- a/src/snowtool/api/routers/stats.py
+++ b/src/snowtool/api/routers/stats.py
@@ -59,7 +59,7 @@ async def _run(
         triplet,
         dataset,
         query,
-        variable_keys=params.variable or None,
+        variable_keys=params.variable,
         zones=params.zone,
         allow_partial=params.allow_partial,
     )

--- a/src/snowtool/cli/stats.py
+++ b/src/snowtool/cli/stats.py
@@ -56,7 +56,9 @@ if TYPE_CHECKING:
     '--variable',
     'variables',
     multiple=True,
-    help='Variable to report (repeatable; default: all of the dataset).',
+    required=True,
+    help='Variable to report (repeatable; at least one required). Reading every '
+    'variable is a multiple of the I/O, so the set is never implicit.',
 )
 @click.option(
     '--allow-partial',
@@ -106,7 +108,7 @@ def stats(
                 triplet,
                 dataset_name,
                 date_query,
-                variable_keys=variables or None,
+                variable_keys=variables,
                 zones=zones,
                 allow_partial=allow_partial,
             ),

--- a/src/snowtool/snowdb/dataset.py
+++ b/src/snowtool/snowdb/dataset.py
@@ -29,14 +29,13 @@ from snowtool.snowdb.raster.cog import SOURCE_HASH_TAG, read_tag
 from snowtool.snowdb.zones.zone_layer_providers import DEFAULT_ZONE_LAYER_PROVIDERS
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator
+    from collections.abc import Callable, Iterable
 
     from griffine.grid import TiledAffineGrid
 
     from snowtool.snowdb.coverage import CoverageDomain
     from snowtool.snowdb.ingest import GridGeometry, IngestResult, WritableRaster
     from snowtool.snowdb.progress import ProgressReporter
-    from snowtool.snowdb.query import DateQuery
     from snowtool.snowdb.spec import DatasetSpec
     from snowtool.snowdb.variables import DatasetVariable
     from snowtool.snowdb.zones.zone_layer import (
@@ -201,20 +200,6 @@ class Dataset:
             tile_size=self.spec.grid_params.tile_size,
             directory=self.zones[provider.name].directory,
         )
-
-    def raster_paths_from_query(
-        self: Self,
-        query: DateQuery,
-        variable: DatasetVariable,
-    ) -> Iterator[tuple[date, Path]]:
-        # Filter the dates that actually exist (one directory listing) rather than
-        # probing every calendar day in the range; this also lets a query carry an
-        # open-ended interval, since selection is over a finite set. Each date's
-        # single COG (and the multiple-match guard) comes from variable_path.
-        for date_ in query.select(self.available_dates()):
-            path = self.variable_path(date_, variable)
-            if path is not None:
-                yield date_, path
 
     def aoi_raster_path_from_triplet(
         self: Self,
@@ -550,24 +535,49 @@ class Dataset:
     ) -> Path | None:
         """The single COG for ``variable`` on date ``d``, or ``None`` if absent.
 
-        Routes through the same :meth:`_glob_matches` engine (and directory
-        listing) as :meth:`_unresolved_variables`, so a date this reports resolved
-        is exactly one the completeness check counts complete.
+        The one-variable form of :meth:`resolve_variables`: same directory
+        listing, same :meth:`_glob_matches` engine, same duplicate-COG raise -- so
+        a date this reports resolved is exactly one the completeness check counts
+        complete.
+        """
+        return self.resolve_variables(d, [variable]).get(variable)
+
+    def resolve_variables(
+        self: Self,
+        d: date,
+        variables: Iterable[DatasetVariable],
+    ) -> dict[DatasetVariable, Path]:
+        """Resolve each of ``variables`` to its single COG for date ``d`` from one
+        directory listing.
+
+        The canonical variable resolver (:meth:`variable_path` is the one-variable
+        form): the date dir is listed *once* and every requested variable is matched
+        against that single listing, so a multi-variable query pays one directory
+        read per date, not one per (date, variable) -- which is what lets a
+        wide-archive query's up-front completeness check fail fast. A variable whose
+        glob matches no file is omitted (:meth:`RasterCollection.validate` turns the
+        resulting partial date into the typed integrity error); a variable matching
+        more than one file raises :class:`IncompleteDatasetDataError`.
         """
         date_dir = self.date_dir(d)
         if not date_dir.is_dir():
-            return None
-        matching = self._glob_matches(self._list_filenames(date_dir), variable.glob)
-        if len(matching) > 1:
-            # Two COGs match one variable's glob -- a stale duplicate that an old
-            # date on disk may still carry. Surface it as the typed integrity error
-            # rather than a bare RuntimeError.
-            raise IncompleteDatasetDataError.for_variables(
-                self.spec.name,
-                d,
-                [variable.key],
-            )
-        return date_dir / matching[0] if matching else None
+            return {}
+        names = self._list_filenames(date_dir)
+        resolved: dict[DatasetVariable, Path] = {}
+        for variable in variables:
+            matching = self._glob_matches(names, variable.glob)
+            if len(matching) > 1:
+                # Two COGs match one variable's glob -- a stale duplicate that an
+                # old date on disk may still carry. Surface it as the typed
+                # integrity error rather than a bare RuntimeError.
+                raise IncompleteDatasetDataError.for_variables(
+                    self.spec.name,
+                    d,
+                    [variable.key],
+                )
+            if matching:
+                resolved[variable] = date_dir / matching[0]
+        return resolved
 
     def unresolved_variables(self: Self, d: date) -> set[str]:
         """Spec variable keys unresolved (missing or duplicated) for date ``d``.

--- a/src/snowtool/snowdb/raster/collection.py
+++ b/src/snowtool/snowdb/raster/collection.py
@@ -56,19 +56,18 @@ class RasterCollection:
         variables: set[DatasetVariable],
         dataset: Dataset,
     ) -> Self:
-        return cls(
-            rasters={
-                variable: [
-                    DataRaster(path, date_)
-                    for date_, path in dataset.raster_paths_from_query(
-                        query,
-                        variable,
-                    )
-                ]
-                for variable in variables
-            },
-            dataset_name=dataset.spec.name,
-        )
+        # Walk the selected dates, resolving all requested variables from each
+        # date's single directory listing (resolve_variables owns the
+        # one-listing-per-date guarantee). Pre-seed every requested variable so
+        # one that is absent on every date still appears as an empty list, which
+        # is what lets validate() flag it as missing rather than pass silently.
+        by_variable: dict[DatasetVariable, list[DataRaster]] = {
+            variable: [] for variable in variables
+        }
+        for date_ in query.select(dataset.available_dates()):
+            for variable, path in dataset.resolve_variables(date_, variables).items():
+                by_variable[variable].append(DataRaster(path, date_))
+        return cls(rasters=by_variable, dataset_name=dataset.spec.name)
 
     def validate(self: Self) -> None:
         # A date present for some requested variables but not others is a partial

--- a/src/snowtool/snowdb/reader.py
+++ b/src/snowtool/snowdb/reader.py
@@ -35,7 +35,7 @@ from snowtool.snowdb.zonal_stats import (
 from snowtool.snowdb.zones.zone_layer import available_zones
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Sequence
 
     from snowtool import types
     from snowtool.snowdb.dataset import Dataset
@@ -78,19 +78,24 @@ class SnowDbReader:
     @staticmethod
     def _resolve_variables(
         dataset: Dataset,
-        variable_keys: Iterable[str] | None,
+        variable_keys: Sequence[str],
     ) -> set[DatasetVariable]:
         """The :class:`DatasetVariable`\\ s named by ``variable_keys``.
 
-        ``None`` (or an empty selection) means every variable the dataset defines;
-        an unknown key raises a clean :class:`QueryParameterError` listing the choices.
+        At least one key is required -- reading every variable is a multiple of the
+        I/O, so the set is never implicit. This raise holds the invariant in the
+        core, for any programmatic caller, not only at the CLI/HTTP boundaries that
+        also enforce it. An unknown key raises a clean :class:`QueryParameterError`
+        listing the choices.
         """
         available = dataset.spec.variables
-        keys = None if variable_keys is None else list(variable_keys)
-        if not keys:
-            return set(available.values())
+        if not variable_keys:
+            raise QueryParameterError(
+                'At least one variable is required; '
+                f'available: {", ".join(sorted(available))}.',
+            )
         resolved: set[DatasetVariable] = set()
-        for key in keys:
+        for key in variable_keys:
             try:
                 resolved.add(available[key])
             except KeyError as e:
@@ -106,7 +111,7 @@ class SnowDbReader:
         dataset_name: str,
         query: DateQuery,
         *,
-        variable_keys: Iterable[str] | None = None,
+        variable_keys: Sequence[str],
         zones: Sequence[ZoneSelection | str] = (),
         allow_partial: bool = False,
     ) -> ZonalStats:
@@ -115,8 +120,9 @@ class SnowDbReader:
         The shared read seam behind the ``stats`` CLI command and the HTTP
         stats routes: it guards coverage, loads the burned AOI raster, resolves the
         requested variables, builds the raster collection for ``query``, and runs
-        the crossed-zone reduction over the reader's cache. ``variable_keys``
-        defaults to every variable the dataset defines. ``zones`` defaults to none
+        the crossed-zone reduction over the reader's cache. ``variable_keys`` names
+        the variables to read (at least one required -- never implicit, since
+        reading every variable is a multiple of the I/O). ``zones`` defaults to none
         (a whole-basin reduction); each element is either an already-resolved
         :class:`~snowtool.snowdb.zonal_stats.ZoneSelection` (the programmatic form)
         or a CLI/HTTP ``LAYER[:PARAM=VALUE]`` string token, parsed here up front

--- a/tests/api/openapi_snapshot.json
+++ b/tests/api/openapi_snapshot.json
@@ -2508,15 +2508,16 @@
             }
           },
           {
-            "description": "Variable to report (repeatable; default: all). Use a variable key from GET /datasets/{dataset}.",
+            "description": "Variable to report (repeatable; at least one required). Use a variable key from GET /datasets/{dataset}. Reading every variable is a multiple of the I/O, so the set is never implicit.",
             "in": "query",
             "name": "variable",
-            "required": false,
+            "required": true,
             "schema": {
-              "description": "Variable to report (repeatable; default: all). Use a variable key from GET /datasets/{dataset}.",
+              "description": "Variable to report (repeatable; at least one required). Use a variable key from GET /datasets/{dataset}. Reading every variable is a multiple of the I/O, so the set is never implicit.",
               "items": {
                 "type": "string"
               },
+              "minItems": 1,
               "title": "Variable",
               "type": "array"
             }
@@ -2712,15 +2713,16 @@
             }
           },
           {
-            "description": "Variable to report (repeatable; default: all). Use a variable key from GET /datasets/{dataset}.",
+            "description": "Variable to report (repeatable; at least one required). Use a variable key from GET /datasets/{dataset}. Reading every variable is a multiple of the I/O, so the set is never implicit.",
             "in": "query",
             "name": "variable",
-            "required": false,
+            "required": true,
             "schema": {
-              "description": "Variable to report (repeatable; default: all). Use a variable key from GET /datasets/{dataset}.",
+              "description": "Variable to report (repeatable; at least one required). Use a variable key from GET /datasets/{dataset}. Reading every variable is a multiple of the I/O, so the set is never implicit.",
               "items": {
                 "type": "string"
               },
+              "minItems": 1,
               "title": "Variable",
               "type": "array"
             }

--- a/tests/api/test_stats.py
+++ b/tests/api/test_stats.py
@@ -251,7 +251,7 @@ def test_malformed_datetime_returns_400(synthetic_client) -> None:
 def test_unknown_format_returns_400(synthetic_client) -> None:
     response = synthetic_client.get(
         f'{BASE}/date-range',
-        params={'datetime': DAY, 'f': 'xml'},
+        params={'datetime': DAY, 'variable': 'swe', 'f': 'xml'},
     )
     assert_problem(response, status=400)
 
@@ -261,9 +261,17 @@ def test_bad_zone_token_returns_422(synthetic_client) -> None:
     # malformed token is a well-formed-but-unprocessable query -- a 422.
     response = synthetic_client.get(
         f'{BASE}/date-range',
-        params={'datetime': DAY, 'zone': 'terrain.elevation:500'},
+        params={'datetime': DAY, 'variable': 'swe', 'zone': 'terrain.elevation:500'},
     )
     assert_problem(response, status=422)
+
+
+def test_absent_variable_returns_400(synthetic_client) -> None:
+    # No implicit "all variables": at least one variable must be requested. An
+    # absent required query param is a malformed request (400), like a malformed
+    # datetime -- not an unprocessable-but-well-formed value (422).
+    response = synthetic_client.get(f'{BASE}/date-range', params={'datetime': DAY})
+    assert_problem(response, status=400)
 
 
 def test_unknown_variable_returns_422(synthetic_client) -> None:
@@ -277,7 +285,7 @@ def test_unknown_variable_returns_422(synthetic_client) -> None:
 def test_unknown_dataset_returns_404(synthetic_client) -> None:
     response = synthetic_client.get(
         f'/datasets/nope/stats/{TRIPLET}/date-range',
-        params={'datetime': DAY},
+        params={'datetime': DAY, 'variable': 'swe'},
     )
     assert_problem(response, status=404)
 
@@ -298,7 +306,13 @@ def test_doy_impossible_day_returns_400(synthetic_client) -> None:
     # problem), not an app-level 422 QueryParameterError.
     response = synthetic_client.get(
         f'{BASE}/doy',
-        params={'month': 2, 'day': 30, 'start_year': 2018, 'end_year': 2018},
+        params={
+            'month': 2,
+            'day': 30,
+            'start_year': 2018,
+            'end_year': 2018,
+            'variable': 'swe',
+        },
     )
     body = assert_problem(
         response,
@@ -311,7 +325,13 @@ def test_doy_impossible_day_returns_400(synthetic_client) -> None:
 def test_doy_inverted_year_span_returns_400(synthetic_client) -> None:
     response = synthetic_client.get(
         f'{BASE}/doy',
-        params={'month': 4, 'day': 27, 'start_year': 2019, 'end_year': 2018},
+        params={
+            'month': 4,
+            'day': 27,
+            'start_year': 2019,
+            'end_year': 2018,
+            'variable': 'swe',
+        },
     )
     body = assert_problem(
         response,

--- a/tests/cli/test_dataset_cli.py
+++ b/tests/cli/test_dataset_cli.py
@@ -640,7 +640,11 @@ def test_inactive_dataset_is_manageable_but_not_queryable(
         _row('2020-01-01', 'ingested', str(source_dem)),
     ]
 
-    refused = runner.invoke(cli, ['stats', 'test', '12345:MT:USGS'], obj=ctx())
+    refused = runner.invoke(
+        cli,
+        ['stats', 'test', '12345:MT:USGS', '--variable', 'swe'],
+        obj=ctx(),
+    )
     assert refused.exit_code != 0
     assert 'registered but inactive' in refused.output
     assert 'dataset activate test' in refused.output

--- a/tests/cli/test_stats_cli.py
+++ b/tests/cli/test_stats_cli.py
@@ -92,12 +92,25 @@ def test_stats_json_compact_value_is_rejected(runner, cli_obj, populated_root):
             TRIPLET,
             '--dates',
             f'{DATE}/{DATE}',
+            '--variable',
+            'swe',
             '--format',
             'json-compact',
         ],
         obj=cli_obj,
     )
     assert result.exit_code == 2  # click Choice rejection
+
+
+def test_stats_requires_variable(runner, cli_obj, populated_root):
+    # No implicit "all variables": at least one --variable must be requested.
+    result = runner.invoke(
+        cli,
+        ['stats', 'test', TRIPLET, '--dates', f'{DATE}/{DATE}'],
+        obj=cli_obj,
+    )
+    assert result.exit_code == 2  # click missing-required-option
+    assert '--variable' in result.output
 
 
 def test_stats_csv_with_elevation_zone(runner, cli_obj, populated_root):

--- a/tests/snowdb/test_ingest.py
+++ b/tests/snowdb/test_ingest.py
@@ -298,6 +298,67 @@ def test_variable_path_duplicate_raises_incomplete(two_var_dataset):
         two_var_dataset.variable_path(d, swe)
 
 
+def test_resolve_variables_resolves_present_and_omits_missing(two_var_dataset):
+    d = date(2020, 1, 5)
+    out = two_var_dataset.date_dir(d)
+    out.mkdir(parents=True)
+    (out / 'srcA__swe.tif').write_text('cog')  # depth deliberately absent
+    swe = two_var_dataset.spec.variables['swe']
+    depth = two_var_dataset.spec.variables['depth']
+
+    resolved = two_var_dataset.resolve_variables(d, [swe, depth])
+
+    # One directory listing resolves every present variable; a missing one is
+    # simply omitted (the completeness check downstream flags the gap).
+    assert resolved == {swe: out / 'srcA__swe.tif'}
+
+
+def test_resolve_variables_absent_date_dir_is_empty(two_var_dataset):
+    swe = two_var_dataset.spec.variables['swe']
+    assert two_var_dataset.resolve_variables(date(2020, 1, 5), [swe]) == {}
+
+
+def test_resolve_variables_duplicate_raises_incomplete(two_var_dataset):
+    d = date(2020, 1, 5)
+    out = two_var_dataset.date_dir(d)
+    out.mkdir(parents=True)
+    (out / 'srcA__swe.tif').write_text('cog')
+    (out / 'srcB__swe.tif').write_text('dup')  # ambiguous swe
+    swe = two_var_dataset.spec.variables['swe']
+
+    with pytest.raises(IncompleteDatasetDataError, match='swe'):
+        two_var_dataset.resolve_variables(d, [swe])
+
+
+def test_collection_build_lists_each_date_dir_once(two_var_dataset, monkeypatch):
+    """Building a multi-variable collection lists each date dir once, not once per
+    variable -- the whole point of the single-pass resolve (fewer directory reads
+    over a wide archive, so the up-front completeness check fails fast)."""
+    from snowtool.snowdb.query import DateRangeQuery
+    from snowtool.snowdb.raster.collection import RasterCollection
+
+    for d in (date(2020, 1, 1), date(2020, 1, 2)):
+        out = two_var_dataset.date_dir(d)
+        out.mkdir(parents=True)
+        (out / 'a__swe.tif').write_text('c')
+        (out / 'a__depth.tif').write_text('c')
+
+    calls: list = []
+    original = two_var_dataset._list_filenames
+
+    def counting(directory):  # observe, don't replace: wrap the real listing
+        calls.append(directory)
+        return original(directory)
+
+    monkeypatch.setattr(two_var_dataset, '_list_filenames', counting)
+    variables = set(two_var_dataset.spec.variables.values())  # swe + depth
+
+    RasterCollection.from_variables_query(DateRangeQuery(), variables, two_var_dataset)
+
+    # 2 dates, not 2 dates x 2 variables.
+    assert len(calls) == 2
+
+
 def test_raster_collection_flags_incomplete_date(tmp_path):
     from snowtool.snowdb.raster.collection import RasterCollection
     from snowtool.snowdb.raster.tiled import DataRaster

--- a/tests/snowdb/test_reader.py
+++ b/tests/snowdb/test_reader.py
@@ -105,6 +105,16 @@ def test_reader_unknown_variable_is_clean_error(reader):
         )
 
 
+def test_reader_empty_variable_selection_is_rejected(reader):
+    # The "never implicit" invariant lives in the core, not just at the CLI/HTTP
+    # boundaries: an empty selection raises rather than silently reading every
+    # (expensive) variable.
+    with pytest.raises(QueryParameterError, match='At least one variable'):
+        asyncio.run(
+            reader.zonal_stats(TRIPLET, 'test', QUERY, variable_keys=[]),
+        )
+
+
 def test_reader_holds_max_zone_cells_from_construction(catalog):
     from snowtool.snowdb.zonal_stats import DEFAULT_MAX_ZONE_CELLS
 
@@ -147,7 +157,7 @@ def test_reader_coverage_guard_rejects_unknown_aoi(reader):
     # The guard runs before any read: an AOI with no stored record cannot be covered.
     with pytest.raises((FileNotFoundError, PourpointCoverageError)):
         asyncio.run(
-            reader.zonal_stats('00000:MT:USGS', 'test', QUERY),
+            reader.zonal_stats('00000:MT:USGS', 'test', QUERY, variable_keys=['swe']),
         )
 
 


### PR DESCRIPTION
- `stats` now requires an explicit variable selection: at least one CLI
  `--variable` or HTTP `variable` query parameter. The implicit "all
  variables" default is gone — reading every variable is a multiple of the
  I/O, so the set is never implicit. A missing `--variable` is a CLI usage
  error; an absent `variable` query parameter is a 400.
- Building a multi-variable raster collection now lists each date directory
  once and resolves every requested variable from that single listing, rather
  than once per (date, variable) — fewer directory reads over a wide archive,
  and a missing-variable date fails fast.
- `SnowDbReader.zonal_stats` now requires a non-empty `variable_keys`; an empty
  selection raises `QueryParameterError` instead of silently reading every
  variable. The "never implicit" rule now holds in the read core, not only at
  the CLI/HTTP boundaries that also enforce it.