### PR TITLE
v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `doctor grid` now validates **every** ingested COG's header (shape + transform)
   against the declared grid, not just the first present COG — a lattice drift on
   any date is caught, and the finding's `target` names the specific file.
+- Health/validation is now expressed as typed `Issue` objects shared by the write
+  path (skip-unless-issues, `force` to bypass) and `doctor` (report), replacing
+  prose-string matching. `doctor`'s grid check now validates the transform/shape of
+  COGs, zone layers, and the nodata mask against the declared grid (AOI-raster grid
+  compatibility is reported under the pourpoints check via the shared AOI health
+  check, which doctor now also uses to report AOI freshness). `aoi_raster_is_current`
+  / `pourpoint rasterize` now treat a grid mismatch (or a corrupt/unreadable raster)
+  as stale, so a grid change rebuilds AOI rasters on the next converge instead of
+  silently leaving them misaligned.
 - `doctor` now reports progress one increment per unit of work — per COG, per
   pourpoint basin (coverage), per AOI raster, per date, plus the atomic
   declaration/orphan/artifact steps — rather than one per (dataset, check). The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   target trips multiple issues (e.g. a basin that is both `no raster` and
   `partial coverage`), the issues are joined with `; ` into one row rather than
   emitting a separate row per issue, so a target never spans multiple lines.
+- The `pourpoint rasterize` skip-check (`Dataset.aoi_raster_is_current`) stays
+  header-only after being unified with `doctor`'s AOI check: it reads the COG
+  header (tags + transform + shape) and never decodes the band, because the only
+  band-decoding check — emptiness — is non-actionable for the writer. This keeps
+  a full-band decode out of the converge loop.
+
+### Added
+
+- A `doctor` reference documentation page (how to run it, its output, and a
+  table of every issue with its meaning and the converge command that fixes it).
+
+### Fixed
+
+- `doctor` no longer appears to hang at startup on a large store. The
+  AOI-validation steps resolved each raster's expected hash — parsing the basin
+  record — *eagerly while enumerating the step list*, before the progress bar
+  opened; that work is now deferred into each step so it shows as bar progress.
+  `doctor` also prints what it is about to check before enumerating.
+- `doctor`'s progress labels render station triplets literally, so a triplet
+  segment like `:id:` (in e.g. `15908000:...:USGS`) is no longer turned into an
+  emoji by the terminal's markup renderer.
 
 ## [v0.4.0] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,64 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Security
 
+## [v0.5.0] - 2026-07-24
+
+> **Live databases (SNODAS grid change — action required):** the SNODAS grid
+> origin moves from the rounded *nominal* corner (`-124.733333 / 52.875`) to
+> SNODAS's *product-header* (native) corner (`-124.73375 / 52.8745833`) — ~0.05
+> px (~40 m) SW. Pixel size and dimensions (6935×3351) are unchanged. This
+> updates only the built-in spec (the template new datasets are created from);
+> an **existing** dataset's grid is persisted inline in its
+> `data/<name>/dataset.json`, so changing the spec does **not** move it — that
+> file's `grid.origin_x`/`origin_y` must be edited (or the dataset re-created
+> from the template). COGs are stamped onto the dataset's declared grid, so once
+> the grid is moved **every existing SNODAS COG sits on the old nominal grid and
+> `doctor grid` flags it**. To converge: **(1)** update the declared grid (spec
+> and/or on-disk `dataset.json`); **(2)** re-ingest the affected dates (raw
+> arrays unchanged; ingest only re-stamps the corrected transform); **(3)**
+> rebuild AOI rasters with `pourpoint rasterize --rebuild` — AOI provenance
+> hashes geometry + nodata mask but **not** the grid, so a plain converge will
+> *not* detect the origin shift and would leave them ~40 m off the COGs;
+> **(4)** regenerate terrain / land-cover zone layers (built on the grid; their
+> provenance tracks source content, not the grid). The shipped nodata mask stays
+> valid — it is applied per-cell on the same grid, so it shifts in lockstep.
+
+### Changed
+
+- The SNODAS dataset spec now declares the product-header grid registration
+  (`-124.73375 / 52.8745833`) instead of the rounded nominal corner, so newly
+  created datasets ingest COGs onto the source `.Hdr`'s true lattice rather than
+  a rounded one. Existing datasets carry their grid in `dataset.json`; see the
+  live-databases note above for moving one.
+- `doctor grid` now validates **every** ingested COG's header (shape + transform)
+  against the declared grid, not just the first present COG — a lattice drift on
+  any date is caught, and the finding's `target` names the specific file.
+- `doctor` now reports progress one increment per unit of work — per COG, per
+  pourpoint basin (coverage), per AOI raster, per date, plus the atomic
+  declaration/orphan/artifact steps — rather than one per (dataset, check). The
+  per-basin coverage scan in particular was previously a single step that stalled
+  the bar while it reprojected an entire pourpoint registry; it now advances one
+  basin at a time. All units are enumerated up front so the bar has an exact
+  total, and each step announces what it is doing (e.g. `snodas pourpoints: AOI
+  validation <triplet>`) as it runs (on a TTY; piped/CI output keeps the single
+  `doctor...` announcement).
+- `doctor` no longer reports the redundant `no raster` finding on an off-grid
+  pourpoint. A basin flagged `no coverage` (its geometry falls entirely outside
+  the dataset grid) cannot be rasterized — `rasterize_aoi` refuses it and the
+  batch path skips it — so a *missing* raster is the expected, healthy state.
+  `no raster` is now suppressed for uncovered basins, leaving only the
+  root-cause `no coverage`; a `partial coverage` basin can still be rasterized,
+  so `no raster` still stands there.
+- The `empty AOI` pourpoint finding is renamed `empty AOI raster` and its
+  message clarified (`covers no in-grid cells: off-grid or masked`), since it
+  reports an on-disk artifact, not the basin. It is *not* suppressed for
+  off-grid basins: the normal flow never writes an all-zero raster for one, so
+  its presence is a stray artifact worth flagging alongside `no coverage`.
+- `doctor` now collapses a target's findings onto one row. When a single
+  target trips multiple issues (e.g. a basin that is both `no raster` and
+  `partial coverage`), the issues are joined with `; ` into one row rather than
+  emitting a separate row per issue, so a target never spans multiple lines.
+
 ## [v0.4.0] - 2026-07-24
 
 ### Changed
@@ -532,7 +590,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release 🎉
 
-[Unreleased]: https://github.com/PSU-CSAR/snowtool/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/PSU-CSAR/snowtool/compare/v0.5.0...HEAD
+[v0.4.1]: https://github.com/PSU-CSAR/snowtool/compare/v0.4.0...v0.4.1
 [v0.4.0]: https://github.com/PSU-CSAR/snowtool/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/PSU-CSAR/snowtool/compare/v0.2.2...v0.3.0
 [v0.2.2]: https://github.com/PSU-CSAR/snowtool/compare/v0.2.1...v0.2.2

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,0 +1,136 @@
+# Checking a snowdb: `doctor`
+
+`snowtool doctor` is a **read-only health inspection** of a snowdb. It never
+changes anything on disk — it opens artifacts, compares them against what the
+config declares, and reports what disagrees. Empty output means healthy; any
+finding makes the command exit non-zero, so it works as a cron/CI gate:
+
+```console
+snowtool doctor                       # all checks, all active datasets
+snowtool doctor grid pourpoints       # only these checks
+snowtool doctor -d snodas             # only this dataset (resolves even if inactive)
+snowtool doctor --format json         # machine-readable rows
+snowtool doctor --include-inactive    # also check registered-but-inactive datasets
+```
+
+Each run prints what it is about to check, then a progress bar with one
+increment per unit of work (per COG, per pourpoint basin, per AOI raster, per
+date). On a large store the enumeration takes a moment; the startup line tells
+you it is working.
+
+## What `doctor` is (and is not) for
+
+`doctor` **detects inconsistencies** between the config and the on-disk reality,
+and structural/alignment/integrity problems it can verify cheaply by reading.
+It does **not** enforce freshness against upstream sources, and it never
+rebuilds anything. Fixing is the job of the converge commands:
+
+| To fix… | Run |
+| --- | --- |
+| Missing or stale COGs | `snowtool dataset ingest …` |
+| Missing or stale AOI rasters | `snowtool pourpoint rasterize [--rebuild]` |
+| Missing or stale zone layers | `snowtool dataset generate-zones …` |
+| A stale coverage index | `snowtool pourpoint reindex` |
+
+So the usual loop is: `doctor` to see what's wrong → the matching converge
+command to fix it → `doctor` again to confirm it's clean.
+
+## Output
+
+Every finding is one row with four fields:
+
+| Field | Meaning |
+| --- | --- |
+| `check` | which check produced it: `grid`, `dates`, `files`, or `pourpoints` |
+| `dataset` | the dataset the finding is about |
+| `target` | what within the dataset — a file, a date, a station triplet, an artifact name |
+| `issue` | a short description of the problem |
+
+When one target trips several issues, they are joined with `; ` onto a single
+row rather than repeated.
+
+## The checks
+
+- **`grid`** — declaration-vs-reality. Flags an ingester that declares no
+  variables, and validates the shape + transform of every full-grid artifact
+  (each COG, each zone-layer file, and the nodata mask) against the declared
+  grid.
+- **`dates`** — every ingested date is complete: each of the dataset's variables
+  resolves to exactly one COG for that date.
+- **`files`** — the dataset's expected artifacts exist (COGs, AOI rasters, zone
+  layers), and built zone-layer sets carry the current on-disk format version.
+- **`pourpoints`** — how the stored pourpoints line up with the dataset's grid
+  and burned AOI rasters: geometric coverage, missing/orphan rasters, and the
+  health of each burned AOI raster (readable, aligned, and current).
+
+## Issues and what to do about them
+
+### `grid`
+
+| Issue (`target`) | Meaning | Fix |
+| --- | --- | --- |
+| `has an ingester but declares no variables` (empty) | A misconfigured dataset spec — an ingester with nothing to write. | Fix the dataset definition. |
+| `declared grid is CxR (cols x rows) but artifact is cxr` (a file) | The file's pixel dimensions don't match the declared grid. | If the *config* is right, rebuild the file (re-ingest / regenerate). If the *file* is right, the declared grid drifted — reconcile it. |
+| `declared grid transform (…) does not match artifact transform (…)` (a file) | The file sits on a different lattice (origin/resolution) than the declared grid. | Same as above. A common cause is changing a dataset's declared grid: re-ingest COGs, `generate-zones` for zone layers, and re-stamp the nodata mask onto the new grid. |
+
+### `dates`
+
+| Issue (`target` = a date) | Meaning | Fix |
+| --- | --- | --- |
+| `missing VAR, VAR, …` | That date is ingested but incomplete — those variables have no COG (or a duplicate COG makes them ambiguous). | Re-ingest the source for that date; remove any duplicate COG. |
+
+### `files`
+
+| Issue (`target`) | Meaning | Fix |
+| --- | --- | --- |
+| `missing` (`cogs`) | No COGs ingested yet. | `dataset ingest`. |
+| `missing` (`aoi-rasters`) | No AOI rasters burned. | `pourpoint rasterize`. |
+| `missing` (`terrain (elevation.tif, …)`) | A zone-layer set is absent or incomplete; the named files are missing. | `dataset generate-zones`. |
+| `stale zone-layer format (stored X != current Y)` (a provider) | The built set's on-disk format version is older than the code's. | `dataset generate-zones` to rebuild. |
+
+### `pourpoints`
+
+| Issue (`target` = a station triplet) | Meaning | Fix |
+| --- | --- | --- |
+| `no coverage` | The basin is entirely outside this dataset's grid. Often expected (e.g. an Alaska station on a CONUS-only dataset). | Usually none. Investigate only if the pourpoint *should* be covered. |
+| `partial coverage` | The basin overlaps the grid but spills outside it; a query uses only the in-grid portion. | Usually informational. Pass `allow_partial` when querying if that's acceptable. |
+| `no raster` | A *covered* basin has no burned AOI raster. | `pourpoint rasterize`. |
+| `orphan raster` | A burned AOI raster exists with no backing pourpoint record. | Remove the stray raster, or restore the record. |
+| `empty AOI raster (covers no in-grid cells: off-grid or masked)` | The burned raster has no in-basin cells — see below. | Depends on cause (below). |
+| `missing SNOWTOOL_TILE_BBOX tag (rebuild with pourpoint rasterize --rebuild)` | A legacy/corrupt AOI raster without its window metadata. | `pourpoint rasterize --rebuild`. |
+| `unreadable: …` | The AOI raster file could not be opened. | `pourpoint rasterize --rebuild`. |
+| `stale content (stored … != expected …)` | The basin changed since the AOI raster was burned (or the nodata mask changed). | `pourpoint rasterize` — the converge rebuilds it. |
+| `declared grid transform (…) does not match artifact transform (…)` | The AOI raster was burned on a grid that has since moved. | `pourpoint rasterize` — a grid move now marks it stale, so the converge rebuilds it. |
+
+## `no coverage` vs. `empty AOI raster`
+
+These look similar but come from different checks and mean different things:
+
+- **`no coverage`** is geometric: the basin polygon does not intersect the
+  dataset's grid at all. Computed live from the stored basin, independent of any
+  raster.
+- **`empty AOI raster`** is about a burned file: an AOI raster exists on disk but
+  is all-zero, so it contributes no pixels to any query.
+
+An off-grid basin cannot be rasterized, so a *missing* raster there is expected
+and `no raster` is suppressed — only `no coverage` is reported. But an all-zero
+raster on disk for an off-grid basin is a **stray artifact** the normal flow
+never writes, so it is flagged (`empty AOI raster`) alongside `no coverage`.
+
+Note that **coverage does not fully predict emptiness.** A basin that *is*
+covered can still burn all-zero when every cell it overlaps is removed by the
+dataset's nodata mask (e.g. a small basin entirely over open water). Coverage is
+a pure geometry test and doesn't consult the mask, so `empty AOI raster` is the
+only signal for that case — which is why the check reads the burned array rather
+than inferring emptiness from coverage.
+
+## Under the hood
+
+The same checks power both `doctor` and the write path: `pourpoint rasterize`
+skips a raster only when the shared AOI-raster check reports no *actionable*
+issue, and rebuilds otherwise (a grid move, a changed basin, a corrupt file, or
+a missing tag all force a rebuild; `--rebuild` forces it regardless). Findings
+are typed objects internally, so `doctor`'s report and the writer's skip decision
+can never drift apart. See
+[Provenance and staleness](internals/provenance.md) for how the underlying
+hashes and format versions work.

--- a/docs/internals/provenance.md
+++ b/docs/internals/provenance.md
@@ -7,8 +7,10 @@ download. Rebuilding them unconditionally on every command would be wasteful;
 trusting whatever is already on disk would be wrong the moment an input changes.
 snowtool splits the difference by stamping each artifact with a **provenance
 tag** that captures exactly what it was built from, and reducing "is this still
-current?" to a single string comparison against what it *would* be built from
-now. The machinery is small, and every downstream check is one equality test.
+current?" to a string comparison against what it *would* be built from now. The
+machinery is small, and each check is a cheap header read plus an equality test
+(the AOI raster's check bundles a few — hash, grid, tile-bbox — since it is
+shared with `doctor`; see below).
 
 The tag is a **versioned hash**: `v{format_version}:{sha256}`, built by
 `versioned_hash(version, digest)` in `snowdb/provenance.py`. The digest covers

--- a/docs/internals/provenance.md
+++ b/docs/internals/provenance.md
@@ -53,11 +53,17 @@ one of the geometry tags.
 canonical little-endian WKB — only the basin polygon, never the point or the
 source properties, because only the polygon affects the burned raster —
 and `aoi_provenance` wraps it with `AOI_RASTER_FORMAT_VERSION`. When a
-`Dataset` rasterizes an AOI it decides whether to rebuild by reading just that
-one tag off the existing COG (`Dataset.aoi_raster_hash`, a header-only
-`tags()` read with no array decode) and comparing it to the current
-`aoi_provenance`. A changed basin *or* a format bump makes them differ, and
-`Dataset.rasterize_aoi` re-burns; a match skips the work entirely.
+`Dataset` rasterizes an AOI it decides whether to rebuild through the shared
+health check `aoi_raster_issues` (`snowdb/aoi_raster.py`) — the same check
+`doctor` reports with, so the writer's skip decision and the reader's report can
+never drift. `Dataset.aoi_raster_is_current` rebuilds when that check finds any
+*actionable* issue and skips otherwise. For the writer the check is header-only
+(a `tags()` read plus the transform/shape, no array decode): it compares the
+stored `SNOWTOOL_AOI_HASH` to the current `aoi_provenance` (a changed basin, a
+changed nodata mask, or a format bump), and *also* the raster's own transform
+against the grid and the presence of its tile-bbox tag — so a grid move or a
+corrupt/unreadable raster now forces a rebuild too, not just a hash mismatch. A
+clean check skips the work entirely; `--rebuild` forces it regardless.
 
 `SNOWTOOL_DEM_HASH` is the versioned hash of a terrain generation's
 mean-elevation array, stamped identically on every layer the pass writes
@@ -114,12 +120,16 @@ current at read time, decoupled from when any basin was last rasterized.
 
 ## Checking staleness in practice
 
-Every staleness check in the codebase is a header-only tag read — `rasterio`'s
-`tags()` without decoding the array — followed by one equality test, so the
-guard is orders of magnitude cheaper than the work it may avoid. The AOI check
-runs in the rasterize path (`Dataset.aoi_raster_is_current`); the source-hash
-check runs in the ingest skip (`Dataset.write_date_cogs`); the format-version
-check surfaces in diagnostics. `stale_format_zone_layers` in
+The staleness checks are header-only reads — `rasterio`'s `tags()` (plus, for
+the AOI check, the transform and shape) without decoding the array — so the
+guard is orders of magnitude cheaper than the work it may avoid. The source-hash
+check runs in the ingest skip (`Dataset.write_date_cogs`) as one equality test;
+the AOI check runs in the rasterize path (`Dataset.aoi_raster_is_current`) and,
+being shared with `doctor`, is a small set of typed checks — hash, grid
+transform/shape, and tile-bbox presence — rather than a single comparison (the
+band-decoding emptiness check is skipped on this path, as it is non-actionable
+for the writer). The format-version check surfaces in diagnostics.
+`stale_format_zone_layers` in
 `snowdb/diagnostics.py` compares each built zone-layer set's stamped format
 version (via `ZoneLayerSet.stored_format_version`) against the provider's
 current one and emits a `ZoneLayerFormat` finding for any mismatch, so

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
   - Configuration: configuration.md
   - Walkthrough: walkthrough.md
   - Usage: usage.md
+  - Checking a snowdb (doctor): doctor.md
   - Internals:
       - Architecture: internals/architecture.md
       - A snowdb on disk: internals/on-disk-layout.md

--- a/src/snowtool/cli/_progress.py
+++ b/src/snowtool/cli/_progress.py
@@ -44,6 +44,9 @@ class _RichTask:
     def advance(self: _RichTask, n: int = 1) -> None:
         self._progress.advance(self._task_id, n)
 
+    def describe(self: _RichTask, label: str) -> None:
+        self._progress.update(self._task_id, description=label)
+
 
 class RichProgress:
     """A :class:`~snowtool.snowdb.progress.ProgressReporter` backed by rich.

--- a/src/snowtool/cli/_progress.py
+++ b/src/snowtool/cli/_progress.py
@@ -83,7 +83,15 @@ class RichProgress:
             return
         progress = Progress(
             SpinnerColumn(),
-            TextColumn('[progress.description]{task.description}'),
+            # markup=False renders the description as literal text: labels carry
+            # station triplets like ``15908000:AK:USGS`` whose ``:...:`` segments
+            # rich would otherwise interpret as console markup / emoji shortcodes
+            # (e.g. ``:id:`` -> an emoji). The style is applied via ``style=``.
+            TextColumn(
+                '{task.description}',
+                style='progress.description',
+                markup=False,
+            ),
             BarColumn(),
             MofNCompleteColumn(),
             TimeElapsedColumn(),

--- a/src/snowtool/cli/doctor.py
+++ b/src/snowtool/cli/doctor.py
@@ -67,6 +67,16 @@ def doctor(
         include_inactive=include_inactive,
     )
 
+    # Announce before enumerating: building the step list across every dataset
+    # (listing COGs, AOI rasters, and pourpoint records) takes a moment on a
+    # large store, and without this the command looks hung before the bar opens.
+    selected = ', '.join(checks) if checks else 'grid, dates, files, pourpoints'
+    names = ', '.join(d.spec.name for d in datasets) or '(none)'
+    _console.err().print(
+        f'[dim]doctor: checking {len(datasets)} dataset(s) ({names}); '
+        f'checks: {selected}. Enumerating…[/dim]',
+    )
+
     findings = diagnostics.run_health_checks(
         snowdb,
         datasets,

--- a/src/snowtool/snowdb/aoi_raster.py
+++ b/src/snowtool/snowdb/aoi_raster.py
@@ -297,6 +297,7 @@ def aoi_raster_issues(
     *,
     grid: TiledAffineGrid,
     expected_hash: str | None,
+    check_empty: bool = True,
 ) -> list[issues_mod.Issue]:
     """The health of the AOI raster at ``path``: freshness + structure + grid.
 
@@ -307,7 +308,11 @@ def aoi_raster_issues(
     corresponding issue), then checks each of the following independently and
     accumulates the results:
 
-    - an all-zero array (:class:`~snowtool.snowdb.issues.EmptyArtifact`);
+    - an all-zero array (:class:`~snowtool.snowdb.issues.EmptyArtifact`) -- the
+      *only* check that decodes the band; gate it off with ``check_empty=False``
+      when the caller does not need it. The writer does exactly that: emptiness
+      is non-actionable (rebuilding an empty-but-current raster reproduces it),
+      so ``aoi_raster_is_current`` skips the decode and reads the header alone;
     - grid + structure: the raster's own on-disk transform and shape against
       what ``grid`` expects for the raster's stored tile-bbox window -- the
       upper-left tile transform and the window's height/width (via
@@ -329,7 +334,9 @@ def aoi_raster_issues(
             actual_transform = ds.transform
             actual_shape = (ds.height, ds.width)
             tags = ds.tags()
-            array = ds.read(1)
+            # The band decode is only needed for the emptiness check; everything
+            # else is header-only, so skip it when the caller opted out.
+            array = ds.read(1) if check_empty else None
         # Resolves the stored tile-bbox against the *current* grid: the UL-tile
         # transform + window shape it yields are what an on-grid raster must
         # match. Raises IncompleteDatasetDataError when the tag is absent.
@@ -341,7 +348,7 @@ def aoi_raster_issues(
 
     result: list[issues_mod.Issue] = []
 
-    if not array.any():
+    if array is not None and not array.any():
         result.append(issues_mod.EmptyArtifact())
 
     result.extend(

--- a/src/snowtool/snowdb/aoi_raster.py
+++ b/src/snowtool/snowdb/aoi_raster.py
@@ -19,6 +19,7 @@ from rasterio.features import rasterize
 from rasterio.windows import Window
 
 from snowtool.exceptions import IncompleteDatasetDataError, NodataMaskError
+from snowtool.snowdb import issues as issues_mod
 from snowtool.snowdb.constants import AOI_HASH_TAG, AOI_MASK_NODATA, TILE_BBOX_TAG
 from snowtool.snowdb.grid import (
     PixelCoord,
@@ -289,6 +290,77 @@ def aoi_provenance(geometry_hash: str, nodata_mask_hash: str | None) -> str:
         else f'{geometry_hash}+{nodata_mask_hash}'
     )
     return versioned_hash(AOI_RASTER_FORMAT_VERSION, digest)
+
+
+def aoi_raster_issues(
+    path: Path,
+    *,
+    grid: TiledAffineGrid,
+    expected_hash: str | None,
+) -> list[issues_mod.Issue]:
+    """The health of the AOI raster at ``path``: freshness + structure + grid.
+
+    The single source of truth for "is this AOI raster OK?", shared by the
+    write path (skip-unless-issues) and ``doctor`` (report). Reads the raster's
+    *own* stored transform, shape, and tags from the file (a missing
+    ``SNOWTOOL_TILE_BBOX`` tag or any other read failure short-circuits with the
+    corresponding issue), then checks each of the following independently and
+    accumulates the results:
+
+    - an all-zero array (:class:`~snowtool.snowdb.issues.EmptyArtifact`);
+    - grid + structure: the raster's own on-disk transform and shape against
+      what ``grid`` expects for the raster's stored tile-bbox window -- the
+      upper-left tile transform and the window's height/width (via
+      :func:`~snowtool.snowdb.issues.grid_issues`). Reading the transform/shape
+      from the *file* (not re-deriving them from ``grid``) is what makes this
+      catch a raster burned on an old grid that has since moved: a shifted grid
+      yields a different expected UL-tile transform than the one on disk. A
+      truncated/corrupt file yields a shape that disagrees with its window.
+    - freshness: when ``expected_hash`` is given, the stored ``SNOWTOOL_AOI_HASH``
+      tag against it (:class:`~snowtool.snowdb.issues.ContentStale`).
+      ``expected_hash=None`` means the caller has no record to compare against
+      (an orphan raster), so freshness is skipped entirely -- that case is
+      reported elsewhere.
+
+    Empty result means healthy and current.
+    """
+    try:
+        with rasterio.open(path) as ds:
+            actual_transform = ds.transform
+            actual_shape = (ds.height, ds.width)
+            tags = ds.tags()
+            array = ds.read(1)
+        # Resolves the stored tile-bbox against the *current* grid: the UL-tile
+        # transform + window shape it yields are what an on-grid raster must
+        # match. Raises IncompleteDatasetDataError when the tag is absent.
+        window = window_from_tags(grid, tags)
+    except IncompleteDatasetDataError:
+        return [issues_mod.MissingProvenanceTag(TILE_BBOX_TAG)]
+    except Exception as e:  # noqa: BLE001 - a health check reports any read failure
+        return [issues_mod.Unreadable(str(e))]
+
+    result: list[issues_mod.Issue] = []
+
+    if not array.any():
+        result.append(issues_mod.EmptyArtifact())
+
+    result.extend(
+        issues_mod.grid_issues(
+            declared_transform=window.tiles[0].transform,
+            actual_transform=actual_transform,
+            declared_shape=(window.height, window.width),
+            actual_shape=actual_shape,
+        ),
+    )
+
+    if expected_hash is not None:
+        stored = tags.get(AOI_HASH_TAG)
+        if stored != expected_hash:
+            result.append(
+                issues_mod.ContentStale(stored=stored, expected=expected_hash),
+            )
+
+    return result
 
 
 def write_aoi_raster(

--- a/src/snowtool/snowdb/dataset.py
+++ b/src/snowtool/snowdb/dataset.py
@@ -19,7 +19,12 @@ from snowtool.exceptions import (
     SnowtoolError,
 )
 from snowtool.snowdb import triplet_naming
-from snowtool.snowdb.aoi_raster import AOIRaster, aoi_provenance, write_aoi_raster
+from snowtool.snowdb.aoi_raster import (
+    AOIRaster,
+    aoi_provenance,
+    aoi_raster_issues,
+    write_aoi_raster,
+)
 from snowtool.snowdb.atomic import staged_dir
 from snowtool.snowdb.constants import AOI_HASH_TAG
 from snowtool.snowdb.pourpoint import Pourpoint
@@ -275,16 +280,25 @@ class Dataset:
         return read_tag(path, AOI_HASH_TAG)
 
     def aoi_raster_is_current(self: Self, pourpoint: Pourpoint) -> bool:
-        """Whether a burned AOI raster exists AND matches ``pourpoint``'s geometry
-        AND the current burned-raster format version.
+        """Whether a burned AOI raster exists AND has no actionable issue.
 
-        ``False`` means missing or stale (changed geometry *or* an old format
-        version) -- either way :meth:`rasterize_aoi` should (re)build it.
+        Delegates to :func:`~snowtool.snowdb.aoi_raster.aoi_raster_issues` -- the
+        same health check ``doctor`` reports with -- so "current" means: the file
+        exists, is readable, is on the current grid, has its tile-bbox tag, and
+        its stored ``SNOWTOOL_AOI_HASH`` matches ``pourpoint``'s geometry (plus
+        this dataset's nodata-mask hash) and the current format version. An
+        empty-but-otherwise-current raster
+        (:class:`~snowtool.snowdb.issues.EmptyArtifact`) still counts as current --
+        rebuilding it would produce the same empty raster, so
+        :meth:`rasterize_aoi` correctly skips it; a corrupt/unreadable raster, a
+        grid move, or a changed basin do not, and force a rebuild.
         """
-        return self.aoi_raster_hash(pourpoint.station_triplet) == aoi_provenance(
-            pourpoint.geometry_hash,
-            self.nodata_mask_hash,
-        )
+        path = self.aoi_raster_path_from_triplet(pourpoint.station_triplet)
+        if not path.is_file():
+            return False
+        expected_hash = aoi_provenance(pourpoint.geometry_hash, self.nodata_mask_hash)
+        found = aoi_raster_issues(path, grid=self.grid, expected_hash=expected_hash)
+        return not any(issue.actionable for issue in found)
 
     def remove_aoi_raster(
         self: Self,

--- a/src/snowtool/snowdb/dataset.py
+++ b/src/snowtool/snowdb/dataset.py
@@ -297,7 +297,15 @@ class Dataset:
         if not path.is_file():
             return False
         expected_hash = aoi_provenance(pourpoint.geometry_hash, self.nodata_mask_hash)
-        found = aoi_raster_issues(path, grid=self.grid, expected_hash=expected_hash)
+        # Header-only: emptiness is non-actionable, so the writer never needs the
+        # band decode -- the actionable checks (hash, grid, tile-bbox) are all in
+        # the header.
+        found = aoi_raster_issues(
+            path,
+            grid=self.grid,
+            expected_hash=expected_hash,
+            check_empty=False,
+        )
         return not any(issue.actionable for issue in found)
 
     def remove_aoi_raster(

--- a/src/snowtool/snowdb/datasets/snodas.py
+++ b/src/snowtool/snowdb/datasets/snodas.py
@@ -507,8 +507,13 @@ SNODAS_VARIABLES = tuple(
 SNODAS_SPEC = DatasetSpec(
     name='snodas',
     grid_params=GridParams(
-        origin_x=-124.733333333333333,
-        origin_y=52.875000000000000,
+        # SNODAS's product-header (native) corner, not the rounded nominal
+        # (-124.733333 / 52.875): the header registration is ~0.05 px (~40 m) SW
+        # of nominal and is what the source .Hdr files declare, so COGs ingested
+        # onto this grid (and the AOI rasters / zone layers burned on it) sit on
+        # the data's true lattice rather than a rounded one.
+        origin_x=-124.73375,
+        origin_y=52.8745833333333,
         px_size=0.008333333333333,
         cols=6935,
         rows=3351,

--- a/src/snowtool/snowdb/diagnostics.py
+++ b/src/snowtool/snowdb/diagnostics.py
@@ -17,11 +17,7 @@ from datetime import date, timedelta
 from functools import partial
 from typing import TYPE_CHECKING
 
-from snowtool.exceptions import (
-    IncompleteDatasetDataError,
-    QueryParameterError,
-    UnknownHealthCheckError,
-)
+from snowtool.exceptions import QueryParameterError, UnknownHealthCheckError
 from snowtool.snowdb import issues as issues_mod
 from snowtool.snowdb import triplet_naming
 from snowtool.snowdb.grid import grid_extent
@@ -134,6 +130,17 @@ type Finding = dict[str, str]
 
 def _finding(check: str, dataset: str, target: str, issue: str) -> Finding:
     return {'check': check, 'dataset': dataset, 'target': target, 'issue': issue}
+
+
+def _findings_from_issues(
+    check: str,
+    dataset: str,
+    target: str,
+    issue_list: Sequence[issues_mod.Issue],
+) -> list[Finding]:
+    """Render a batch of typed :class:`~snowtool.snowdb.issues.Issue` to findings
+    sharing one ``check``/``dataset``/``target``."""
+    return [_finding(check, dataset, target, i.message) for i in issue_list]
 
 
 def completeness_report(
@@ -261,41 +268,35 @@ def pourpoint_coverage_report(snowdb: SnowDb, dataset: Dataset) -> list[Finding]
 def aoi_health_report(dataset: Dataset) -> list[Finding]:
     """``pourpoints`` findings for burned AOI rasters that won't read cleanly.
 
-    Opens each AOI raster; a read failure, a missing tile-bbox tag, or an
-    all-zero (empty) raster becomes a finding whose ``target`` is the station
-    triplet and whose ``issue`` describes the fault.
+    Opens each AOI raster; a read failure, a missing tile-bbox tag, a grid
+    mismatch, or an all-zero (empty) raster becomes a finding whose ``target``
+    is the station triplet and whose ``issue`` describes the fault. Freshness
+    is not checked here (no registry is available to resolve an expected hash
+    against) -- see :func:`_aoi_raster_findings` for the doctor step that adds it.
     """
     findings: list[Finding] = []
     for path in dataset.aoi_raster_paths():
-        findings.extend(_aoi_raster_health(dataset, path))
+        findings.extend(_aoi_raster_findings(dataset, path.stem, path, None))
     return findings
 
 
-def _aoi_raster_health(dataset: Dataset, path: Path) -> list[Finding]:
-    """The ``pourpoints`` finding (if any) for one burned AOI raster."""
-    from snowtool.snowdb.aoi_raster import AOIRaster
+def _aoi_raster_findings(
+    dataset: Dataset,
+    stem: str,
+    path: Path,
+    expected_hash: str | None,
+) -> list[Finding]:
+    """The ``pourpoints`` findings for one burned AOI raster.
 
-    triplet = triplet_naming.stem_to_triplet(path.stem)
-    issue: str | None = None
-    try:
-        aoi_raster = AOIRaster.open(path, dataset.grid)
-    except IncompleteDatasetDataError:
-        issue = (
-            'missing SNOWTOOL_TILE_BBOX tag (rebuild with `pourpoint rasterize '
-            '--rebuild`)'
-        )
-    except Exception as e:  # noqa: BLE001 - a health scan reports any read failure
-        issue = f'unreadable: {e}'
-    else:
-        # Burned to all-zero (no in-basin cell area): the basin covers no in-grid
-        # cells, so the raster would contribute no pixels to any query -- either
-        # the basin is off-grid (a stray raster that should not exist) or it is
-        # on-grid but entirely over masked/nodata pixels.
-        if not aoi_raster.array.any():
-            issue = 'empty AOI raster (covers no in-grid cells: off-grid or masked)'
-    if issue is None:
-        return []
-    return [_finding('pourpoints', dataset.spec.name, triplet, issue)]
+    Delegates to :func:`~snowtool.snowdb.aoi_raster.aoi_raster_issues` -- the
+    shared structure/grid/freshness check -- and renders its typed
+    :class:`~snowtool.snowdb.issues.Issue` list to findings.
+    """
+    from snowtool.snowdb.aoi_raster import aoi_raster_issues
+
+    triplet = triplet_naming.stem_to_triplet(stem)
+    found = aoi_raster_issues(path, grid=dataset.grid, expected_hash=expected_hash)
+    return _findings_from_issues('pourpoints', dataset.spec.name, triplet, found)
 
 
 @dataclass(frozen=True)
@@ -689,13 +690,18 @@ def _pourpoint_coverage_findings(
         dataset.coverage_domain,
     )
     if coverage is Coverage.NONE:
-        return [_finding('pourpoints', name, triplet, 'no coverage')]
-    findings: list[Finding] = []
+        return _findings_from_issues(
+            'pourpoints',
+            name,
+            triplet,
+            [issues_mod.NoCoverage()],
+        )
+    found: list[issues_mod.Issue] = []
     if triplet not in rasterized:
-        findings.append(_finding('pourpoints', name, triplet, 'no raster'))
+        found.append(issues_mod.NoRaster())
     if coverage is Coverage.PARTIAL:
-        findings.append(_finding('pourpoints', name, triplet, 'partial coverage'))
-    return findings
+        found.append(issues_mod.PartialCoverage())
+    return _findings_from_issues('pourpoints', name, triplet, found)
 
 
 def _orphan_raster_findings(
@@ -704,10 +710,17 @@ def _orphan_raster_findings(
     triplets: set[str],
 ) -> list[Finding]:
     """``orphan raster`` findings: burned rasters with no backing record."""
-    return [
-        _finding('pourpoints', name, triplet, 'orphan raster')
-        for triplet in sorted(rasterized - triplets)
-    ]
+    findings: list[Finding] = []
+    for triplet in sorted(rasterized - triplets):
+        findings.extend(
+            _findings_from_issues(
+                'pourpoints',
+                name,
+                triplet,
+                [issues_mod.OrphanArtifact()],
+            ),
+        )
+    return findings
 
 
 def _pourpoints_steps(snowdb: SnowDb, dataset: Dataset) -> list[CheckStep]:
@@ -741,13 +754,38 @@ def _pourpoints_steps(snowdb: SnowDb, dataset: Dataset) -> list[CheckStep]:
     )
     for path in dataset.aoi_raster_paths():
         triplet = triplet_naming.stem_to_triplet(path.stem)
+        expected_hash = _expected_aoi_hash(snowdb, dataset, triplet)
         steps.append(
             CheckStep(
                 f'{name} pourpoints: AOI validation {triplet}',
-                partial(_aoi_raster_health, dataset, path),
+                partial(
+                    _aoi_raster_findings,
+                    dataset,
+                    path.stem,
+                    path,
+                    expected_hash,
+                ),
             ),
         )
     return steps
+
+
+def _expected_aoi_hash(
+    snowdb: SnowDb,
+    dataset: Dataset,
+    triplet: str,
+) -> str | None:
+    """The AOI provenance hash a raster for ``triplet`` should carry, or ``None``
+    when there is no backing basin record to compare against (an orphan raster,
+    reported separately by :func:`_orphan_raster_findings`)."""
+    from snowtool.snowdb.aoi_raster import aoi_provenance
+    from snowtool.snowdb.pourpoint import Pourpoint
+
+    record_path = snowdb.pourpoint_record_path(triplet)
+    if not record_path.is_file():
+        return None
+    pourpoint = Pourpoint.from_basin_record(record_path)
+    return aoi_provenance(pourpoint.geometry_hash, dataset.nodata_mask_hash)
 
 
 # Order is the ``doctor`` output/CLI-help order.

--- a/src/snowtool/snowdb/diagnostics.py
+++ b/src/snowtool/snowdb/diagnostics.py
@@ -14,6 +14,7 @@ import math
 
 from dataclasses import dataclass
 from datetime import date, timedelta
+from functools import partial
 from typing import TYPE_CHECKING
 
 from snowtool.exceptions import (
@@ -27,7 +28,7 @@ from snowtool.snowdb.progress import NULL_PROGRESS
 from snowtool.snowdb.query import DateRangeQuery
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Iterator, Sequence
     from pathlib import Path
 
     from affine import Affine
@@ -144,21 +145,26 @@ def completeness_report(
 ) -> list[Finding]:
     """``dates`` findings: ingested dates (optionally within ``start``/``end``)
     missing one or more of their dataset's variables."""
-    name = dataset.spec.name
-    findings: list[Finding] = []
     window = DateRangeQuery(start_date=start, end_date=end)
+    findings: list[Finding] = []
     for d in window.select(dataset.available_dates()):
-        unresolved = dataset.unresolved_variables(d)
-        if unresolved:
-            findings.append(
-                _finding(
-                    'dates',
-                    name,
-                    d.isoformat(),
-                    f'missing {", ".join(sorted(unresolved))}',
-                ),
-            )
+        findings.extend(_date_completeness(dataset, d))
     return findings
+
+
+def _date_completeness(dataset: Dataset, d: date) -> list[Finding]:
+    """The ``dates`` finding (if any) for a single ingested date ``d``."""
+    unresolved = dataset.unresolved_variables(d)
+    if not unresolved:
+        return []
+    return [
+        _finding(
+            'dates',
+            dataset.spec.name,
+            d.isoformat(),
+            f'missing {", ".join(sorted(unresolved))}',
+        ),
+    ]
 
 
 def missing_artifacts(dataset: Dataset) -> list[str]:
@@ -260,30 +266,37 @@ def aoi_health_report(dataset: Dataset) -> list[Finding]:
     all-zero (empty) raster becomes a finding whose ``target`` is the station
     triplet and whose ``issue`` describes the fault.
     """
-    from snowtool.snowdb.aoi_raster import AOIRaster
-
-    name = dataset.spec.name
     findings: list[Finding] = []
     for path in dataset.aoi_raster_paths():
-        triplet = triplet_naming.stem_to_triplet(path.stem)
-        issue: str | None = None
-        try:
-            aoi_raster = AOIRaster.open(path, dataset.grid)
-        except IncompleteDatasetDataError:
-            issue = (
-                'missing SNOWTOOL_TILE_BBOX tag '
-                '(rebuild with `pourpoint rasterize --rebuild`)'
-            )
-        except Exception as e:  # noqa: BLE001 - a health scan reports any read failure
-            issue = f'unreadable: {e}'
-        else:
-            # Burned to all-zero (no in-basin cell area): the AOI polygon falls
-            # outside the grid, so it would contribute no pixels to any query.
-            if not aoi_raster.array.any():
-                issue = 'empty AOI (does not overlap the grid, or is entirely masked)'
-        if issue is not None:
-            findings.append(_finding('pourpoints', name, triplet, issue))
+        findings.extend(_aoi_raster_health(dataset, path))
     return findings
+
+
+def _aoi_raster_health(dataset: Dataset, path: Path) -> list[Finding]:
+    """The ``pourpoints`` finding (if any) for one burned AOI raster."""
+    from snowtool.snowdb.aoi_raster import AOIRaster
+
+    triplet = triplet_naming.stem_to_triplet(path.stem)
+    issue: str | None = None
+    try:
+        aoi_raster = AOIRaster.open(path, dataset.grid)
+    except IncompleteDatasetDataError:
+        issue = (
+            'missing SNOWTOOL_TILE_BBOX tag (rebuild with `pourpoint rasterize '
+            '--rebuild`)'
+        )
+    except Exception as e:  # noqa: BLE001 - a health scan reports any read failure
+        issue = f'unreadable: {e}'
+    else:
+        # Burned to all-zero (no in-basin cell area): the basin covers no in-grid
+        # cells, so the raster would contribute no pixels to any query -- either
+        # the basin is off-grid (a stray raster that should not exist) or it is
+        # on-grid but entirely over masked/nodata pixels.
+        if not aoi_raster.array.any():
+            issue = 'empty AOI raster (covers no in-grid cells: off-grid or masked)'
+    if issue is None:
+        return []
+    return [_finding('pourpoints', dataset.spec.name, triplet, issue)]
 
 
 @dataclass(frozen=True)
@@ -489,14 +502,16 @@ def dataset_info_report(snowdb: SnowDb, dataset: Dataset) -> DatasetInfoReport:
     )
 
 
-def _first_present_cog(dataset: Dataset) -> Path | None:
-    """The first variable COG present on disk (scanning dates ascending)."""
+def _iter_cog_paths(dataset: Dataset) -> Iterator[Path]:
+    """Every ingested COG on disk, ascending by date then filename.
+
+    Lists each ``cogs/<date>/`` directory once and yields all its ``.tif`` files,
+    so the grid check can validate *every* data file's header (not just a
+    representative), and tolerate a stray/duplicate COG a per-variable resolve
+    would raise on.
+    """
     for d in dataset.available_dates():
-        for variable in dataset.spec.variables.values():
-            path = dataset.variable_path(d, variable)
-            if path is not None:
-                return path
-    return None
+        yield from sorted(dataset.date_dir(d).glob('*.tif'))
 
 
 def _transforms_close(a: Affine, b: Affine) -> bool:
@@ -507,95 +522,251 @@ def _transforms_close(a: Affine, b: Affine) -> bool:
     )
 
 
-def grid_validation_report(dataset: Dataset) -> list[str]:
-    """Cheap declaration-vs-reality checks for ``snowtool doctor``.
+def _grid_declaration_issues(dataset: Dataset) -> list[str]:
+    """The declaration-only grid problems (no raster I/O).
 
-    Returns a list of human-readable problems (empty == consistent):
+    An ingester with no variables has nothing to write -- almost certainly a
+    misconfiguration. (The reverse -- variables but no ingester -- is *not*
+    flagged: that is a valid read-only/derived dataset, populated out of band.)
+    A deeper variables-vs-ingester check (the ingester's *required* keys being a
+    subset of those declared) would need the ``Ingester`` protocol to expose its
+    expected keys; that is left as a follow-up.
+    """
+    spec = dataset.spec
+    if spec.ingester is not None and not spec.variables:
+        return ['has an ingester but declares no variables']
+    return []
 
-    1. **Ingester vs variables.** An ingester with no variables has nothing to
-       write -- almost certainly a misconfiguration. (The reverse -- variables but
-       no ingester -- is *not* flagged: that is a valid read-only/derived dataset,
-       populated out of band.)
-    2. **Declared grid vs the first present COG.** Opens the first variable COG on
-       disk and checks its shape + transform against the declared grid, catching a
-       config that has drifted from the real rasters. Skipped when no COG exists
-       yet (that is a completeness concern, not an inconsistency).
 
-    A deeper variables-vs-ingester check (the ingester's *required* variable keys
-    being a subset of those declared) would need the ``Ingester`` protocol to
-    expose its expected keys; that is left as a follow-up.
+def _cog_grid_issues(dataset: Dataset, cog: Path) -> list[str]:
+    """Shape + transform problems for one COG against the declared grid.
+
+    Opens ``cog``'s header and checks its dimensions and transform against the
+    dataset's declared grid, catching a config that has drifted from the real
+    rasters (or a file ingested onto a different lattice).
     """
     import rasterio
 
+    grid = dataset.spec.grid_params
+    declared = dataset.grid.base_grid.transform
+    with rasterio.open(cog) as src:
+        actual = src.transform
+        width, height = src.width, src.height
     issues: list[str] = []
-    spec = dataset.spec
-
-    if spec.ingester is not None and not spec.variables:
-        issues.append('has an ingester but declares no variables')
-
-    cog = _first_present_cog(dataset)
-    if cog is not None:
-        grid = spec.grid_params
-        declared = dataset.grid.base_grid.transform
-        with rasterio.open(cog) as src:
-            actual = src.transform
-            width, height = src.width, src.height
-        if (width, height) != (grid.cols, grid.rows):
-            issues.append(
-                f'declared grid is {grid.cols}x{grid.rows} (cols x rows) but COG '
-                f'{cog.name} is {width}x{height}',
-            )
-        if not _transforms_close(declared, actual):
-            issues.append(
-                f'declared grid transform {tuple(declared)[:6]} does not match '
-                f'COG {cog.name} transform {tuple(actual)[:6]}',
-            )
+    if (width, height) != (grid.cols, grid.rows):
+        issues.append(
+            f'declared grid is {grid.cols}x{grid.rows} (cols x rows) but COG '
+            f'{cog.name} is {width}x{height}',
+        )
+    if not _transforms_close(declared, actual):
+        issues.append(
+            f'declared grid transform {tuple(declared)[:6]} does not match '
+            f'COG {cog.name} transform {tuple(actual)[:6]}',
+        )
     return issues
 
 
-# --- doctor: the health-check registry ---------------------------------------
+def grid_validation_report(dataset: Dataset) -> list[str]:
+    """Declaration-vs-reality grid problems (empty == consistent).
+
+    The declaration check (:func:`_grid_declaration_issues`) plus the shape +
+    transform check (:func:`_cog_grid_issues`) run against **every** ingested
+    COG, so a lattice drift on any date is caught, not just the first. The
+    ``doctor`` sweep enumerates the same work one COG at a time for progress
+    (see :func:`_grid_steps`); this aggregate is for direct callers/tests.
+    """
+    issues = _grid_declaration_issues(dataset)
+    for cog in _iter_cog_paths(dataset):
+        issues.extend(_cog_grid_issues(dataset, cog))
+    return issues
+
+
+# --- doctor: enumerable health-check steps -----------------------------------
 #
-# Every check has the one uniform ``(snowdb, dataset) -> list[Finding]``
-# signature :func:`run_health_checks` dispatches through -- only ``pourpoints``
-# actually needs the whole-db pourpoint registry to compare against, but the
-# others take ``snowdb`` too so the registry needs no per-check wrapping. Each
-# builder already emits ``Finding`` rows directly (composing ``target``/``issue``
-# where the condition is detected); the checks below only compose the two that
-# wrap a bare-string helper (``grid_validation_report``, ``missing_artifacts``)
-# and roll the two pourpoint scans together.
+# `run_health_checks` shows one progress increment per unit of work, so a check
+# is not a single ``(snowdb, dataset) -> findings`` call but an *enumeration* of
+# `CheckStep`s: a live-progress label plus a deferred `run`. Enumeration only
+# lists directories (cheap); each `run` does the expensive open/parse. Listing
+# every step across all datasets up front lets the reporter set an exact total
+# and announce each unit (a COG, an AOI raster, a date) as it runs.
 
 
-def _grid_check(_snowdb: SnowDb, dataset: Dataset) -> list[Finding]:
-    name = dataset.spec.name
+@dataclass(frozen=True)
+class CheckStep:
+    """One unit of ``doctor`` work: a progress ``label`` and a deferred ``run``
+    that produces its findings when executed."""
+
+    label: str
+    run: Callable[[], list[Finding]]
+
+
+def _grid_declaration_findings(dataset: Dataset, name: str) -> list[Finding]:
     return [
-        _finding('grid', name, '', issue) for issue in grid_validation_report(dataset)
+        _finding('grid', name, '', issue) for issue in _grid_declaration_issues(dataset)
     ]
 
 
-def _dates_check(_snowdb: SnowDb, dataset: Dataset) -> list[Finding]:
-    return completeness_report(dataset)
+def _cog_grid_findings(
+    dataset: Dataset,
+    name: str,
+    cog: Path,
+    target: str,
+) -> list[Finding]:
+    return [
+        _finding('grid', name, target, issue)
+        for issue in _cog_grid_issues(dataset, cog)
+    ]
 
 
-def _files_check(_snowdb: SnowDb, dataset: Dataset) -> list[Finding]:
+def _grid_steps(_snowdb: SnowDb, dataset: Dataset) -> list[CheckStep]:
     name = dataset.spec.name
-    findings = [
+    steps = [
+        CheckStep(
+            f'{name} grid: declaration',
+            partial(_grid_declaration_findings, dataset, name),
+        ),
+    ]
+    # One step per COG so every data file's header is validated (not just a
+    # representative), each advancing the bar under its own label.
+    for cog in _iter_cog_paths(dataset):
+        target = f'{cog.parent.name}/{cog.name}'
+        steps.append(
+            CheckStep(
+                f'{name} grid: {target}',
+                partial(_cog_grid_findings, dataset, name, cog, target),
+            ),
+        )
+    return steps
+
+
+def _dates_steps(_snowdb: SnowDb, dataset: Dataset) -> list[CheckStep]:
+    name = dataset.spec.name
+    return [
+        CheckStep(
+            f'{name} dates: {d.isoformat()}',
+            partial(_date_completeness, dataset, d),
+        )
+        for d in dataset.available_dates()
+    ]
+
+
+def _missing_artifact_findings(dataset: Dataset, name: str) -> list[Finding]:
+    return [
         _finding('files', name, artifact, 'missing')
         for artifact in missing_artifacts(dataset)
     ]
-    findings.extend(stale_format_zone_layers(dataset))
+
+
+def _files_steps(_snowdb: SnowDb, dataset: Dataset) -> list[CheckStep]:
+    name = dataset.spec.name
+    return [
+        CheckStep(
+            f'{name} files: artifacts',
+            partial(_missing_artifact_findings, dataset, name),
+        ),
+        CheckStep(
+            f'{name} files: zone-layer formats',
+            partial(stale_format_zone_layers, dataset),
+        ),
+    ]
+
+
+def _pourpoint_coverage_findings(
+    dataset: Dataset,
+    record_path: Path,
+    triplet: str,
+    rasterized: frozenset[str],
+) -> list[Finding]:
+    """Coverage findings for one pourpoint basin (parses + reprojects it).
+
+    This is the per-basin unit of the coverage scan -- the expensive part
+    (parsing the record and reprojecting the basin into the grid CRS), one
+    pourpoint at a time so ``doctor``'s bar advances through a large registry
+    instead of stalling on a single monolithic step.
+
+    An off-grid basin (``NONE``) cannot be rasterized -- ``rasterize_aoi`` refuses
+    it and the batch path skips it -- so a *missing* raster is expected and only
+    ``no coverage`` is reported (a *stray* all-zero raster is still caught by the
+    per-raster AOI-validation steps). A ``PARTIAL`` basin can and should be
+    rasterized, so ``no raster`` stands there. Issue order (``no raster`` before
+    ``partial coverage``) matches the collapsed-row order the tests pin.
+    """
+    from snowtool.snowdb.coverage import Coverage, dataset_coverage
+    from snowtool.snowdb.pourpoint import Pourpoint
+
+    name = dataset.spec.name
+    coverage = dataset_coverage(
+        Pourpoint.from_basin_record(record_path),
+        dataset.coverage_domain,
+    )
+    if coverage is Coverage.NONE:
+        return [_finding('pourpoints', name, triplet, 'no coverage')]
+    findings: list[Finding] = []
+    if triplet not in rasterized:
+        findings.append(_finding('pourpoints', name, triplet, 'no raster'))
+    if coverage is Coverage.PARTIAL:
+        findings.append(_finding('pourpoints', name, triplet, 'partial coverage'))
     return findings
 
 
-def _pourpoints_check(snowdb: SnowDb, dataset: Dataset) -> list[Finding]:
-    return pourpoint_coverage_report(snowdb, dataset) + aoi_health_report(dataset)
+def _orphan_raster_findings(
+    name: str,
+    rasterized: frozenset[str],
+    triplets: set[str],
+) -> list[Finding]:
+    """``orphan raster`` findings: burned rasters with no backing record."""
+    return [
+        _finding('pourpoints', name, triplet, 'orphan raster')
+        for triplet in sorted(rasterized - triplets)
+    ]
+
+
+def _pourpoints_steps(snowdb: SnowDb, dataset: Dataset) -> list[CheckStep]:
+    name = dataset.spec.name
+    # Cheap up front (filenames + a glob); the per-basin reprojection is deferred
+    # into one step each so the progress total is exact and the bar advances.
+    rasterized = frozenset(dataset.aoi_raster_triplets())
+    steps = [
+        CheckStep(
+            f'{name} pourpoints: coverage {triplet_naming.stem_to_triplet(p.stem)}',
+            partial(
+                _pourpoint_coverage_findings,
+                dataset,
+                p,
+                triplet_naming.stem_to_triplet(p.stem),
+                rasterized,
+            ),
+        )
+        for p in snowdb.pourpoint_paths()
+    ]
+    steps.append(
+        CheckStep(
+            f'{name} pourpoints: orphan rasters',
+            partial(
+                _orphan_raster_findings,
+                name,
+                rasterized,
+                snowdb.pourpoint_triplets(),
+            ),
+        ),
+    )
+    for path in dataset.aoi_raster_paths():
+        triplet = triplet_naming.stem_to_triplet(path.stem)
+        steps.append(
+            CheckStep(
+                f'{name} pourpoints: AOI validation {triplet}',
+                partial(_aoi_raster_health, dataset, path),
+            ),
+        )
+    return steps
 
 
 # Order is the ``doctor`` output/CLI-help order.
-HEALTH_CHECKS: dict[str, Callable[[SnowDb, Dataset], list[Finding]]] = {
-    'grid': _grid_check,
-    'dates': _dates_check,
-    'files': _files_check,
-    'pourpoints': _pourpoints_check,
+HEALTH_CHECKS: dict[str, Callable[[SnowDb, Dataset], list[CheckStep]]] = {
+    'grid': _grid_steps,
+    'dates': _dates_steps,
+    'files': _files_steps,
+    'pourpoints': _pourpoints_steps,
 }
 
 # The valid check names, in ``doctor``'s output/default-sweep order.
@@ -615,8 +786,11 @@ def run_health_checks(
     Resolves ``checks`` first: an unknown name raises
     :class:`~snowtool.exceptions.UnknownHealthCheckError`, duplicates are
     dropped (order-preserving), and an empty selection defaults to every check
-    in :data:`HEALTH_CHECK_NAMES`. Then runs every (dataset, check) pair,
-    advancing ``progress`` one tick per pair.
+    in :data:`HEALTH_CHECK_NAMES`. Then enumerates every check's steps (one per
+    COG, AOI raster, date, ...) across all datasets up front so ``progress`` has
+    an exact total, and runs each step, naming it on the bar and advancing one
+    tick per step. Findings sharing a ``(check, dataset, target)`` are collapsed
+    onto one row (:func:`_collapse_by_target`).
     """
     unknown = sorted(set(checks) - set(HEALTH_CHECK_NAMES))
     if unknown:
@@ -626,10 +800,33 @@ def run_health_checks(
         )
     selected = list(dict.fromkeys(checks)) if checks else list(HEALTH_CHECK_NAMES)
 
+    steps: list[CheckStep] = []
+    for dataset in datasets:
+        for check in selected:
+            steps.extend(HEALTH_CHECKS[check](snowdb, dataset))
+
     findings: list[Finding] = []
-    with progress.track('doctor', total=len(datasets) * len(selected)) as task:
-        for dataset in datasets:
-            for check in selected:
-                findings.extend(HEALTH_CHECKS[check](snowdb, dataset))
-                task.advance()
-    return findings
+    with progress.track('doctor', total=len(steps)) as task:
+        for step in steps:
+            task.describe(step.label)
+            findings.extend(step.run())
+            task.advance()
+    return _collapse_by_target(findings)
+
+
+def _collapse_by_target(findings: Sequence[Finding]) -> list[Finding]:
+    """Roll findings that share a ``(check, dataset, target)`` onto one row.
+
+    A target that trips several issues (e.g. a basin that is both ``no raster``
+    and ``partial coverage``) becomes a single row whose ``issue`` joins them with
+    ``'; '`` -- so ``doctor`` never spreads one target across multiple lines --
+    preserving first-seen order both across rows and within the joined issue.
+    """
+    collapsed: dict[tuple[str, str, str], Finding] = {}
+    for finding in findings:
+        key = (finding['check'], finding['dataset'], finding['target'])
+        if (existing := collapsed.get(key)) is not None:
+            existing['issue'] += f'; {finding["issue"]}'
+        else:
+            collapsed[key] = dict(finding)
+    return list(collapsed.values())

--- a/src/snowtool/snowdb/diagnostics.py
+++ b/src/snowtool/snowdb/diagnostics.py
@@ -608,6 +608,35 @@ def _cog_grid_findings(
     ]
 
 
+def _full_grid_findings(
+    dataset: Dataset,
+    name: str,
+    path: Path,
+    target: str,
+) -> list[Finding]:
+    """The ``grid`` findings for one full-grid-sized raster (a zone layer or the
+    nodata mask), against the dataset's declared grid.
+
+    Unlike a COG (also full-grid) or an AOI raster (a windowed crop, checked
+    under ``pourpoints``), this is a plain full-grid comparison: the file's own
+    transform/shape against ``dataset.spec.grid_params`` and
+    ``dataset.grid.base_grid.transform``.
+    """
+    import rasterio
+
+    grid = dataset.spec.grid_params
+    with rasterio.open(path) as src:
+        actual_transform = src.transform
+        actual_shape = (src.height, src.width)
+    found = issues_mod.grid_issues(
+        declared_transform=dataset.grid.base_grid.transform,
+        actual_transform=actual_transform,
+        declared_shape=(grid.rows, grid.cols),
+        actual_shape=actual_shape,
+    )
+    return _findings_from_issues('grid', name, target, found)
+
+
 def _grid_steps(_snowdb: SnowDb, dataset: Dataset) -> list[CheckStep]:
     name = dataset.spec.name
     steps = [
@@ -624,6 +653,35 @@ def _grid_steps(_snowdb: SnowDb, dataset: Dataset) -> list[CheckStep]:
             CheckStep(
                 f'{name} grid: {target}',
                 partial(_cog_grid_findings, dataset, name, cog, target),
+            ),
+        )
+    # One step per present zone-layer file (terrain: elevation/aspect, land
+    # cover: forest, ...) -- a missing layer is the `files` check's concern, not
+    # grid, so only files that actually exist on disk are validated here.
+    for provider_name, zone_set in dataset.zones.items():
+        for layer in zone_set.layers:
+            path = zone_set.layer_path(layer)
+            if not path.is_file():
+                continue
+            target = f'{provider_name}/{layer.filename}'
+            steps.append(
+                CheckStep(
+                    f'{name} grid: {target}',
+                    partial(_full_grid_findings, dataset, name, path, target),
+                ),
+            )
+    # The dataset's nodata mask (when configured) is also a full-grid raster.
+    if dataset.nodata_mask is not None and dataset.nodata_mask.is_file():
+        steps.append(
+            CheckStep(
+                f'{name} grid: nodata-mask.tif',
+                partial(
+                    _full_grid_findings,
+                    dataset,
+                    name,
+                    dataset.nodata_mask,
+                    'nodata-mask.tif',
+                ),
             ),
         )
     return steps

--- a/src/snowtool/snowdb/diagnostics.py
+++ b/src/snowtool/snowdb/diagnostics.py
@@ -22,6 +22,7 @@ from snowtool.exceptions import (
     QueryParameterError,
     UnknownHealthCheckError,
 )
+from snowtool.snowdb import issues as issues_mod
 from snowtool.snowdb import triplet_naming
 from snowtool.snowdb.grid import grid_extent
 from snowtool.snowdb.progress import NULL_PROGRESS
@@ -30,8 +31,6 @@ from snowtool.snowdb.query import DateRangeQuery
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
     from pathlib import Path
-
-    from affine import Affine
 
     from snowtool.snowdb.dataset import Dataset, DatasetArtifacts
     from snowtool.snowdb.db import SnowDb
@@ -514,14 +513,6 @@ def _iter_cog_paths(dataset: Dataset) -> Iterator[Path]:
         yield from sorted(dataset.date_dir(d).glob('*.tif'))
 
 
-def _transforms_close(a: Affine, b: Affine) -> bool:
-    """Whether two affine transforms agree to within float noise."""
-    return all(
-        math.isclose(x, y, rel_tol=1e-9, abs_tol=1e-9)
-        for x, y in zip(tuple(a)[:6], tuple(b)[:6], strict=True)
-    )
-
-
 def _grid_declaration_issues(dataset: Dataset) -> list[str]:
     """The declaration-only grid problems (no raster I/O).
 
@@ -543,7 +534,10 @@ def _cog_grid_issues(dataset: Dataset, cog: Path) -> list[str]:
 
     Opens ``cog``'s header and checks its dimensions and transform against the
     dataset's declared grid, catching a config that has drifted from the real
-    rasters (or a file ingested onto a different lattice).
+    rasters (or a file ingested onto a different lattice). Delegates the
+    comparison to :func:`snowtool.snowdb.issues.grid_issues` -- the same check
+    used for every other grid-bound artifact -- and renders each returned
+    ``Issue`` back to a string so callers keep their ``list[str]`` shape.
     """
     import rasterio
 
@@ -552,18 +546,13 @@ def _cog_grid_issues(dataset: Dataset, cog: Path) -> list[str]:
     with rasterio.open(cog) as src:
         actual = src.transform
         width, height = src.width, src.height
-    issues: list[str] = []
-    if (width, height) != (grid.cols, grid.rows):
-        issues.append(
-            f'declared grid is {grid.cols}x{grid.rows} (cols x rows) but COG '
-            f'{cog.name} is {width}x{height}',
-        )
-    if not _transforms_close(declared, actual):
-        issues.append(
-            f'declared grid transform {tuple(declared)[:6]} does not match '
-            f'COG {cog.name} transform {tuple(actual)[:6]}',
-        )
-    return issues
+    found = issues_mod.grid_issues(
+        declared_transform=declared,
+        actual_transform=actual,
+        declared_shape=(grid.rows, grid.cols),
+        actual_shape=(height, width),
+    )
+    return [issue.message for issue in found]
 
 
 def grid_validation_report(dataset: Dataset) -> list[str]:

--- a/src/snowtool/snowdb/diagnostics.py
+++ b/src/snowtool/snowdb/diagnostics.py
@@ -812,20 +812,28 @@ def _pourpoints_steps(snowdb: SnowDb, dataset: Dataset) -> list[CheckStep]:
     )
     for path in dataset.aoi_raster_paths():
         triplet = triplet_naming.stem_to_triplet(path.stem)
-        expected_hash = _expected_aoi_hash(snowdb, dataset, triplet)
         steps.append(
             CheckStep(
                 f'{name} pourpoints: AOI validation {triplet}',
-                partial(
-                    _aoi_raster_findings,
-                    dataset,
-                    path.stem,
-                    path,
-                    expected_hash,
-                ),
+                # Defer both the record parse (expected hash) and the raster read
+                # into the step body -- computing them here, during enumeration,
+                # parses every basin record before the progress bar opens.
+                partial(_aoi_raster_step_findings, snowdb, dataset, path),
             ),
         )
     return steps
+
+
+def _aoi_raster_step_findings(
+    snowdb: SnowDb,
+    dataset: Dataset,
+    path: Path,
+) -> list[Finding]:
+    """A doctor AOI-validation step: resolve the expected hash from the registry
+    (deferred), then run the shared AOI check."""
+    triplet = triplet_naming.stem_to_triplet(path.stem)
+    expected_hash = _expected_aoi_hash(snowdb, dataset, triplet)
+    return _aoi_raster_findings(dataset, path.stem, path, expected_hash)
 
 
 def _expected_aoi_hash(

--- a/src/snowtool/snowdb/issues.py
+++ b/src/snowtool/snowdb/issues.py
@@ -9,11 +9,15 @@ string via ``message``, and declares whether re-writing the artifact resolves it
 
 from __future__ import annotations
 
+import math
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+    from affine import Affine
 
 
 @dataclass(frozen=True)
@@ -180,3 +184,37 @@ class UnverifiableFreshness(Issue):
 def render(issues: Iterable[Issue]) -> str:
     """Join issue messages with '; ' (doctor's one-row-per-target rendering)."""
     return '; '.join(issue.message for issue in issues)
+
+
+def grid_issues(
+    *,
+    declared_transform: Affine,
+    actual_transform: Affine,
+    declared_shape: tuple[int, int],
+    actual_shape: tuple[int, int],
+) -> list[Issue]:
+    """Grid-compatibility issues for any grid-bound artifact.
+
+    Compares an artifact's transform + shape to the declared grid. Shape must be
+    exact; the transform is compared to within float noise (the artifacts are
+    written from the same declared grid, so a real mismatch is a drift, not
+    rounding). Empty result == aligned.
+    """
+    result: list[Issue] = []
+    if actual_shape != declared_shape:
+        result.append(ShapeMismatch(declared=declared_shape, actual=actual_shape))
+    if not _transforms_close(declared_transform, actual_transform):
+        result.append(
+            GridMismatch(
+                declared=tuple(declared_transform)[:6],
+                actual=tuple(actual_transform)[:6],
+            ),
+        )
+    return result
+
+
+def _transforms_close(a: Affine, b: Affine) -> bool:
+    return all(
+        math.isclose(x, y, rel_tol=1e-9, abs_tol=1e-9)
+        for x, y in zip(tuple(a)[:6], tuple(b)[:6], strict=True)
+    )

--- a/src/snowtool/snowdb/issues.py
+++ b/src/snowtool/snowdb/issues.py
@@ -105,6 +105,10 @@ class Unreadable(Issue):
     detail: str = ''
 
     @property
+    def actionable(self) -> bool:
+        return True
+
+    @property
     def message(self) -> str:
         return f'unreadable: {self.detail}'
 

--- a/src/snowtool/snowdb/issues.py
+++ b/src/snowtool/snowdb/issues.py
@@ -1,0 +1,182 @@
+"""Typed validation issues shared by the write path (skip-unless-issues) and the
+read path (`doctor` reporting).
+
+An ``Issue`` is one thing wrong with (or worth noting about) an artifact. It is
+``isinstance``-checkable (no prose matching in code), renders itself to a human
+string via ``message``, and declares whether re-writing the artifact resolves it
+(``actionable``). A check returns ``list[Issue]`` -- empty means current/healthy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+@dataclass(frozen=True)
+class Issue:
+    """One validation problem. Subclasses set fields and override ``message``."""
+
+    @property
+    def actionable(self) -> bool:
+        """Whether re-writing/rebuilding the artifact resolves this issue."""
+        return False
+
+    @property
+    def message(self) -> str:  # pragma: no cover - overridden by every subclass
+        raise NotImplementedError
+
+    def __str__(self) -> str:
+        return self.message
+
+
+@dataclass(frozen=True)
+class GridMismatch(Issue):
+    declared: tuple[float, ...] = ()
+    actual: tuple[float, ...] = ()
+
+    @property
+    def actionable(self) -> bool:
+        return True
+
+    @property
+    def message(self) -> str:
+        return (
+            f'declared grid transform {self.declared} does not match '
+            f'artifact transform {self.actual}'
+        )
+
+
+@dataclass(frozen=True)
+class ShapeMismatch(Issue):
+    declared: tuple[int, int] = (0, 0)
+    actual: tuple[int, int] = (0, 0)
+
+    @property
+    def actionable(self) -> bool:
+        return True
+
+    @property
+    def message(self) -> str:
+        dcols, drows = self.declared[1], self.declared[0]
+        return (
+            f'declared grid is {dcols}x{drows} (cols x rows) but artifact is '
+            f'{self.actual[1]}x{self.actual[0]}'
+        )
+
+
+@dataclass(frozen=True)
+class ContentStale(Issue):
+    stored: str | None = None
+    expected: str = ''
+
+    @property
+    def actionable(self) -> bool:
+        return True
+
+    @property
+    def message(self) -> str:
+        return f'stale content (stored {self.stored} != expected {self.expected})'
+
+
+@dataclass(frozen=True)
+class FormatStale(Issue):
+    stored: int | None = None
+    current: int = 0
+
+    @property
+    def actionable(self) -> bool:
+        return True
+
+    @property
+    def message(self) -> str:
+        return f'stale format (stored {self.stored} != current {self.current})'
+
+
+@dataclass(frozen=True)
+class Unreadable(Issue):
+    detail: str = ''
+
+    @property
+    def message(self) -> str:
+        return f'unreadable: {self.detail}'
+
+
+@dataclass(frozen=True)
+class EmptyArtifact(Issue):
+    @property
+    def message(self) -> str:
+        return 'empty AOI raster (covers no in-grid cells: off-grid or masked)'
+
+
+@dataclass(frozen=True)
+class MissingProvenanceTag(Issue):
+    tag: str = ''
+
+    @property
+    def actionable(self) -> bool:
+        return True
+
+    @property
+    def message(self) -> str:
+        return f'missing {self.tag} tag (rebuild with `pourpoint rasterize --rebuild`)'
+
+
+@dataclass(frozen=True)
+class OrphanArtifact(Issue):
+    @property
+    def message(self) -> str:
+        return 'orphan raster'
+
+
+@dataclass(frozen=True)
+class MissingArtifact(Issue):
+    @property
+    def actionable(self) -> bool:
+        return True
+
+    @property
+    def message(self) -> str:
+        return 'missing'
+
+
+@dataclass(frozen=True)
+class NoCoverage(Issue):
+    @property
+    def message(self) -> str:
+        return 'no coverage'
+
+
+@dataclass(frozen=True)
+class PartialCoverage(Issue):
+    @property
+    def message(self) -> str:
+        return 'partial coverage'
+
+
+@dataclass(frozen=True)
+class NoRaster(Issue):
+    @property
+    def actionable(self) -> bool:
+        return True
+
+    @property
+    def message(self) -> str:
+        return 'no raster'
+
+
+@dataclass(frozen=True)
+class UnverifiableFreshness(Issue):
+    reason: str = ''
+
+    @property
+    def message(self) -> str:
+        return f'freshness unverifiable: {self.reason}'
+
+
+def render(issues: Iterable[Issue]) -> str:
+    """Join issue messages with '; ' (doctor's one-row-per-target rendering)."""
+    return '; '.join(issue.message for issue in issues)

--- a/src/snowtool/snowdb/progress.py
+++ b/src/snowtool/snowdb/progress.py
@@ -25,6 +25,14 @@ class ProgressTask(Protocol):
 
     def advance(self, n: int = 1) -> None: ...
 
+    def describe(self, label: str) -> None:
+        """Update the task's live label (what it is currently working on).
+
+        A no-op for reporters that render a fixed label; the CLI reporter swaps
+        the description so a single tracked bar can name each unit as it runs.
+        """
+        ...
+
 
 class ProgressReporter(Protocol):
     """Opens a tracked task for a long operation.
@@ -44,6 +52,9 @@ class ProgressReporter(Protocol):
 
 class _NullTask:
     def advance(self: _NullTask, n: int = 1) -> None:
+        pass
+
+    def describe(self: _NullTask, label: str) -> None:
         pass
 
 

--- a/tests/snowdb/test_grid.py
+++ b/tests/snowdb/test_grid.py
@@ -84,6 +84,18 @@ def test_tiling_shape() -> None:
     assert SNODAS_GRID.tile_size == (256, 256)
 
 
+def test_snodas_spec_declares_the_header_grid_registration() -> None:
+    # SNODAS COG headers carry the product's native corner (-124.73375 /
+    # 52.8745833) -- the rounded nominal (-124.733333 / 52.875) is ~0.05 px
+    # (~40 m) NE of it. The spec declares the header registration so ingested
+    # COGs sit on the source's true lattice (and AOI rasters/zone layers, all
+    # burned on this grid, agree with it). Pixel size and dimensions are unchanged.
+    assert _GP.origin_x == -124.73375
+    assert _GP.origin_y == pytest.approx(52.8745833333333, abs=1e-10)
+    assert _GP.px_size == 0.008333333333333
+    assert (_GP.cols, _GP.rows) == (6935, 3351)
+
+
 def test_point_to_tile_matches_pixel_floor_div() -> None:
     pt = Point(-115.087346, 47.301864)
     cell = SNODAS_GRID.base_grid.point_to_cell(pt)

--- a/tests/snowdb/test_issues.py
+++ b/tests/snowdb/test_issues.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from affine import Affine
+
 from snowtool.snowdb import issues
 
 
@@ -64,3 +66,58 @@ def test_render_joins_messages_in_order():
     joined = issues.render([issues.NoRaster(), issues.PartialCoverage()])
     assert joined == 'no raster; partial coverage'
     assert issues.render([]) == ''
+
+
+def test_grid_issues_clean_when_matching():
+    t = Affine(0.00833333, 0.0, -124.73375, 0.0, -0.00833333, 52.8745833)
+    assert (
+        issues.grid_issues(
+            declared_transform=t,
+            actual_transform=t,
+            declared_shape=(3351, 6935),
+            actual_shape=(3351, 6935),
+        )
+        == []
+    )
+
+
+def test_grid_issues_flags_transform_and_shape():
+    declared = Affine(0.00833333, 0.0, -124.73375, 0.0, -0.00833333, 52.8745833)
+    actual = Affine(0.00833333, 0.0, -124.73333, 0.0, -0.00833333, 52.875)
+    result = issues.grid_issues(
+        declared_transform=declared,
+        actual_transform=actual,
+        declared_shape=(3351, 6935),
+        actual_shape=(256, 256),
+    )
+    types = {type(i) for i in result}
+    assert issues.ShapeMismatch in types
+    assert issues.GridMismatch in types
+
+
+def test_grid_issues_tolerates_float_noise():
+    a = Affine(
+        0.008333333333333,
+        0.0,
+        -124.73375,
+        0.0,
+        -0.008333333333333,
+        52.8745833333333,
+    )
+    b = Affine(
+        0.008333333333333,
+        0.0,
+        -124.7337499999950,
+        0.0,
+        -0.008333333333333,
+        52.8745833333312,
+    )
+    assert (
+        issues.grid_issues(
+            declared_transform=a,
+            actual_transform=b,
+            declared_shape=(3351, 6935),
+            actual_shape=(3351, 6935),
+        )
+        == []
+    )

--- a/tests/snowdb/test_issues.py
+++ b/tests/snowdb/test_issues.py
@@ -1,0 +1,66 @@
+"""Unit tests for the typed validation Issue vocabulary."""
+
+import pytest
+
+from snowtool.snowdb import issues
+
+
+@pytest.mark.parametrize(
+    ('issue', 'expected_message', 'actionable'),
+    [
+        (issues.NoCoverage(), 'no coverage', False),
+        (issues.PartialCoverage(), 'partial coverage', False),
+        (issues.NoRaster(), 'no raster', True),
+        (issues.OrphanArtifact(), 'orphan raster', False),
+        (
+            issues.EmptyArtifact(),
+            'empty AOI raster (covers no in-grid cells: off-grid or masked)',
+            False,
+        ),
+        (issues.MissingArtifact(), 'missing', True),
+        (issues.Unreadable('boom'), 'unreadable: boom', False),
+        (
+            issues.MissingProvenanceTag('SNOWTOOL_TILE_BBOX'),
+            'missing SNOWTOOL_TILE_BBOX tag '
+            '(rebuild with `pourpoint rasterize --rebuild`)',
+            True,
+        ),
+        (
+            issues.FormatStale(stored=2, current=3),
+            'stale format (stored 2 != current 3)',
+            True,
+        ),
+        (
+            issues.FormatStale(stored=None, current=3),
+            'stale format (stored None != current 3)',
+            True,
+        ),
+        (
+            issues.UnverifiableFreshness('source absent'),
+            'freshness unverifiable: source absent',
+            False,
+        ),
+    ],
+)
+def test_issue_message_and_actionability(issue, expected_message, actionable):
+    assert issue.message == expected_message
+    assert str(issue) == expected_message
+    assert issue.actionable is actionable
+
+
+def test_grid_and_shape_mismatch_messages():
+    g = issues.GridMismatch(declared=(0.1, 0.0, -124.7), actual=(0.1, 0.0, -124.73))
+    assert 'declared grid transform' in g.message
+    assert '(0.1, 0.0, -124.7)' in g.message
+    assert '(0.1, 0.0, -124.73)' in g.message
+    assert g.actionable is True
+    s = issues.ShapeMismatch(declared=(3351, 6935), actual=(256, 256))
+    assert '6935' in s.message
+    assert '256x256' in s.message
+    assert s.actionable is True
+
+
+def test_render_joins_messages_in_order():
+    joined = issues.render([issues.NoRaster(), issues.PartialCoverage()])
+    assert joined == 'no raster; partial coverage'
+    assert issues.render([]) == ''

--- a/tests/snowdb/test_issues.py
+++ b/tests/snowdb/test_issues.py
@@ -20,7 +20,7 @@ from snowtool.snowdb import issues
             False,
         ),
         (issues.MissingArtifact(), 'missing', True),
-        (issues.Unreadable('boom'), 'unreadable: boom', False),
+        (issues.Unreadable('boom'), 'unreadable: boom', True),
         (
             issues.MissingProvenanceTag('SNOWTOOL_TILE_BBOX'),
             'missing SNOWTOOL_TILE_BBOX tag '

--- a/tests/snowdb/test_pourpoint_manager.py
+++ b/tests/snowdb/test_pourpoint_manager.py
@@ -585,6 +585,39 @@ def test_format_version_bump_makes_aoi_raster_stale(db, pourpoint_geojson, monke
     assert ds.aoi_raster_is_current(aoi) is True
 
 
+def test_aoi_raster_is_current_after_rasterize(dataset, pourpoint_geojson):
+    pp = Pourpoint.from_geojson(pourpoint_geojson)
+    dataset.rasterize_aoi(pp)
+    assert dataset.aoi_raster_is_current(pp) is True
+
+
+def test_aoi_raster_stale_when_geometry_changes(dataset, pourpoint_geojson, tmp_path):
+    pp = Pourpoint.from_geojson(pourpoint_geojson)
+    dataset.rasterize_aoi(pp)
+
+    # Same triplet, a different basin polygon -> a different geometry_hash, so
+    # the on-disk SNOWTOOL_AOI_HASH no longer matches: ContentStale, actionable.
+    changed = _write_aoi(
+        tmp_path / 'changed',
+        '12345:MT:USGS',
+        polygon=box(-119.8, 44.8, -119.1, 44.1),
+    )
+    changed_pp = Pourpoint.from_geojson(changed)
+    assert dataset.aoi_raster_is_current(changed_pp) is False
+
+
+def test_aoi_raster_stale_when_unreadable(dataset, pourpoint_geojson):
+    pp = Pourpoint.from_geojson(pourpoint_geojson)
+    dataset.rasterize_aoi(pp)
+
+    path = dataset.aoi_raster_path_from_triplet(pp.station_triplet)
+    path.write_bytes(b'not a tiff')
+
+    # A corrupt/unreadable raster is now actionable (rewriting fixes it), so it
+    # must read as not-current -- the regression guard for the Unreadable fix.
+    assert dataset.aoi_raster_is_current(pp) is False
+
+
 def test_rasterize_aoi_builds_then_skips_then_rebuilds(
     db,
     pourpoint_geojson,

--- a/tests/snowdb/test_report_diagnostics.py
+++ b/tests/snowdb/test_report_diagnostics.py
@@ -645,6 +645,25 @@ def test_aoi_raster_issues_clean_for_current_raster(dataset, pourpoint_geojson):
     assert result == []
 
 
+def test_aoi_raster_issues_check_empty_false_skips_the_band_decode(dataset, grid):
+    # The emptiness check is the only one that decodes the band; the writer opts
+    # out (check_empty=False) since emptiness is non-actionable. An all-zero
+    # raster is flagged EmptyArtifact by default but not when the decode is off.
+    _write_empty_aoi(dataset, grid, '99999:MT:USGS')
+    path = dataset.aoi_raster_path_from_triplet('99999:MT:USGS')
+
+    with_empty = aoi_raster_issues(path, grid=dataset.grid, expected_hash=None)
+    without = aoi_raster_issues(
+        path,
+        grid=dataset.grid,
+        expected_hash=None,
+        check_empty=False,
+    )
+
+    assert any(isinstance(i, issues_mod.EmptyArtifact) for i in with_empty)
+    assert not any(isinstance(i, issues_mod.EmptyArtifact) for i in without)
+
+
 def test_aoi_raster_issues_clean_for_offset_basin(dataset, tmp_path):
     # False-positive guard: a basin whose tile-bbox does NOT start at tile (0, 0)
     # must still be clean. Its UL-tile transform is offset from the grid origin,

--- a/tests/snowdb/test_report_diagnostics.py
+++ b/tests/snowdb/test_report_diagnostics.py
@@ -11,6 +11,8 @@ import rasterio
 
 from snowtool.exceptions import PourpointCoverageError
 from snowtool.snowdb import diagnostics
+from snowtool.snowdb import issues as issues_mod
+from snowtool.snowdb.aoi_raster import aoi_provenance, aoi_raster_issues
 from snowtool.snowdb.constants import TILE_BBOX_TAG
 from snowtool.snowdb.coverage import Coverage
 from snowtool.snowdb.dataset import Dataset
@@ -24,10 +26,13 @@ from snowtool.snowdb.zones.landcover_layers import FOREST_COVER
 from snowtool.snowdb.zones.terrain_layers import ELEVATION
 
 from ..conftest import (
+    ORIGIN_X,
+    PX,
     TILE,
     make_snowdb,
     register_dataset_config,
     snodas_swe_name,
+    synthetic_grid,
     write_landcover,
     write_pourpoint_record,
     write_swe_cog,
@@ -549,6 +554,83 @@ def test_aoi_health_reports_missing_tile_bbox(dataset, grid):
 
     bad = diagnostics.aoi_health_report(dataset)
     assert any('TILE_BBOX' in h['issue'] for h in bad)
+
+
+def test_aoi_raster_issues_clean_for_current_raster(dataset, pourpoint_geojson):
+    pp = Pourpoint.from_geojson(pourpoint_geojson)
+    dataset.rasterize_aoi(pp)
+    path = dataset.aoi_raster_path_from_triplet(pp.station_triplet)
+
+    result = aoi_raster_issues(
+        path,
+        grid=dataset.grid,
+        expected_hash=aoi_provenance(pp.geometry_hash, dataset.nodata_mask_hash),
+    )
+
+    assert result == []
+
+
+def test_aoi_raster_issues_clean_for_offset_basin(dataset, tmp_path):
+    # False-positive guard: a basin whose tile-bbox does NOT start at tile (0, 0)
+    # must still be clean. Its UL-tile transform is offset from the grid origin,
+    # so comparing the raster's own transform (not the grid base transform) is
+    # what keeps this from spuriously flagging GridMismatch. The synthetic grid
+    # spans lon [-120, -114.88], lat [39.88, 45]; a box around (-115.5, 40.2)
+    # lands in tile (1, 1).
+    record = _write_basin(
+        tmp_path,
+        '55555:MT:USGS',
+        x0=-115.7,
+        y0=40.0,
+        x1=-115.3,
+        y1=40.4,
+    )
+    pp = Pourpoint.from_geojson(record)
+    dataset.rasterize_aoi(pp)
+    path = dataset.aoi_raster_path_from_triplet(pp.station_triplet)
+
+    result = aoi_raster_issues(
+        path,
+        grid=dataset.grid,
+        expected_hash=aoi_provenance(pp.geometry_hash, dataset.nodata_mask_hash),
+    )
+
+    assert result == []
+
+
+def test_aoi_raster_issues_flags_grid_drift(dataset, pourpoint_geojson):
+    # True-positive: the SAME on-disk raster, read against a grid whose origin is
+    # shifted by one pixel, must be flagged -- proving real grid drift (not a
+    # value re-derived from the current grid) is detected.
+    pp = Pourpoint.from_geojson(pourpoint_geojson)
+    dataset.rasterize_aoi(pp)
+    path = dataset.aoi_raster_path_from_triplet(pp.station_triplet)
+
+    shifted_grid = synthetic_grid(origin_x=ORIGIN_X + PX)
+
+    result = aoi_raster_issues(
+        path,
+        grid=shifted_grid,
+        expected_hash=aoi_provenance(pp.geometry_hash, dataset.nodata_mask_hash),
+    )
+
+    assert any(isinstance(i, issues_mod.GridMismatch) for i in result)
+    assert all(i.actionable for i in result if isinstance(i, issues_mod.GridMismatch))
+
+
+def test_aoi_raster_issues_flags_stale_hash(dataset, pourpoint_geojson):
+    pp = Pourpoint.from_geojson(pourpoint_geojson)
+    dataset.rasterize_aoi(pp)
+    path = dataset.aoi_raster_path_from_triplet(pp.station_triplet)
+
+    result = aoi_raster_issues(
+        path,
+        grid=dataset.grid,
+        expected_hash='v1:deadbeef',  # deliberately not what was stamped
+    )
+
+    assert any(isinstance(i, issues_mod.ContentStale) for i in result)
+    assert all(i.actionable for i in result if isinstance(i, issues_mod.ContentStale))
 
 
 # --- value-ranges / grid -----------------------------------------------------

--- a/tests/snowdb/test_report_diagnostics.py
+++ b/tests/snowdb/test_report_diagnostics.py
@@ -13,7 +13,7 @@ from snowtool.exceptions import PourpointCoverageError
 from snowtool.snowdb import diagnostics
 from snowtool.snowdb import issues as issues_mod
 from snowtool.snowdb.aoi_raster import aoi_provenance, aoi_raster_issues
-from snowtool.snowdb.constants import TILE_BBOX_TAG
+from snowtool.snowdb.constants import AOI_HASH_TAG, AOI_MASK_NODATA, TILE_BBOX_TAG
 from snowtool.snowdb.coverage import Coverage
 from snowtool.snowdb.dataset import Dataset
 from snowtool.snowdb.datasets import config_from_spec
@@ -350,16 +350,29 @@ def test_guard_wiring(guard_db, triplet, allow_partial, expectation):
 # --- pourpoints check: dedup + per-target roll-up ----------------------------
 
 
-def _write_empty_aoi(dataset, grid, triplet):
-    """Write an all-zero (but readable) AOI raster for ``triplet``."""
+def _write_empty_aoi(dataset, grid, triplet, *, record_path=None):
+    """Write an all-zero (but readable) AOI raster for ``triplet``.
+
+    When ``record_path`` (the triplet's stored basin record) is given, stamps
+    ``SNOWTOOL_AOI_HASH`` to match it so this hand-written stray/empty raster
+    reads as *current*, not stale -- these fixtures are about emptiness, not
+    freshness, which is covered separately.
+    """
     dataset._aoi_rasters.mkdir(parents=True, exist_ok=True)
+    tags = {TILE_BBOX_TAG: '0 0 0 0'}
+    if record_path is not None:
+        pourpoint = Pourpoint.from_basin_record(record_path)
+        tags[AOI_HASH_TAG] = aoi_provenance(
+            pourpoint.geometry_hash,
+            dataset.nodata_mask_hash,
+        )
     write_cog(
         dataset._aoi_rasters / f'{triplet.replace(":", "_")}.tif',
         numpy.zeros((TILE, TILE), dtype=numpy.float32),
         transform=grid.base_grid[0, 0].transform,
         tile_size=TILE,
         nodata=0,
-        tags={TILE_BBOX_TAG: '0 0 0 0'},
+        tags=tags,
         compute_stats=False,
     )
 
@@ -371,7 +384,7 @@ def test_pourpoints_check_reports_stray_raster_for_uncovered_basin(created_db, g
     # (`empty AOI raster`) alongside the root-cause `no coverage`, rolled onto one
     # row in coverage-then-health order.
     db, ds = created_db
-    _write_basin(
+    record_path = _write_basin(
         db.pourpoint_records_path,
         '300:MT:USGS',
         x0=-110.0,
@@ -379,7 +392,7 @@ def test_pourpoints_check_reports_stray_raster_for_uncovered_basin(created_db, g
         x1=-109.0,
         y1=44.0,
     )
-    _write_empty_aoi(ds, grid, '300:MT:USGS')
+    _write_empty_aoi(ds, grid, '300:MT:USGS', record_path=record_path)
 
     findings = diagnostics.run_health_checks(db, [ds], ['pourpoints'])
 
@@ -417,7 +430,7 @@ def test_pourpoints_check_keeps_empty_aoi_for_covered_basin(created_db, grid):
     # fault: `empty AOI raster` is reported here just as it is for the off-grid
     # stray-raster case -- an all-zero raster always surfaces, covered or not.
     db, ds = created_db
-    _write_basin(
+    record_path = _write_basin(
         db.pourpoint_records_path,
         '100:MT:USGS',
         x0=-119.9,
@@ -425,7 +438,7 @@ def test_pourpoints_check_keeps_empty_aoi_for_covered_basin(created_db, grid):
         x1=-119.0,
         y1=44.0,
     )
-    _write_empty_aoi(ds, grid, '100:MT:USGS')
+    _write_empty_aoi(ds, grid, '100:MT:USGS', record_path=record_path)
 
     findings = diagnostics.run_health_checks(db, [ds], ['pourpoints'])
 
@@ -453,6 +466,68 @@ def test_pourpoints_check_rolls_up_issues_for_one_target(created_db):
     for_200 = [f for f in findings if f['target'] == '200:MT:USGS']
     assert len(for_200) == 1
     assert for_200[0]['issue'] == 'no raster; partial coverage'
+
+
+def test_doctor_pourpoints_reports_stale_aoi_hash(created_db, pourpoint_geojson):
+    # Doctor now routes AOI validation through `aoi_raster_issues`, so a raster
+    # whose stamped SNOWTOOL_AOI_HASH no longer matches its basin record's
+    # current geometry hash (a basin edited out from under an already-rasterized
+    # pourpoint) is reported -- not just structural/emptiness faults.
+    db, ds = created_db
+    shutil.copy(
+        pourpoint_geojson,
+        db.pourpoint_records_path / '12345_MT_USGS.geojson',
+    )
+    pp = Pourpoint.from_geojson(pourpoint_geojson)
+    ds.rasterize_aoi(pp)
+    path = ds.aoi_raster_path_from_triplet(pp.station_triplet)
+
+    # Re-stamp the raster's AOI-hash tag with a bogus value, simulating drift
+    # between the stored record and the burned raster's provenance.
+    with rasterio.open(path) as src:
+        array = src.read(1)
+        transform = src.transform
+        crs = src.crs
+        tags = dict(src.tags())
+    tags[AOI_HASH_TAG] = 'v1:deadbeef'
+    write_cog(
+        path,
+        array,
+        transform=transform,
+        crs=crs,
+        nodata=AOI_MASK_NODATA,
+        tile_size=TILE,
+        tags=tags,
+        compute_stats=False,
+    )
+
+    findings = diagnostics.run_health_checks(db, [ds], ['pourpoints'])
+
+    for_pp = [f for f in findings if f['target'] == pp.station_triplet]
+    assert len(for_pp) == 1
+    assert 'stale content' in for_pp[0]['issue']
+
+
+def test_doctor_pourpoints_no_spurious_findings_for_offset_basin(created_db, tmp_path):
+    # A basin whose tile-bbox does not start at tile (0, 0) must not spuriously
+    # trip the AOI-validation step now that it also checks grid-compat +
+    # freshness through `aoi_raster_issues` -- a normal, correctly-rasterized
+    # offset basin still reports nothing for `pourpoints`.
+    db, ds = created_db
+    record_path = _write_basin(
+        db.pourpoint_records_path,
+        '55555:MT:USGS',
+        x0=-115.7,
+        y0=40.0,
+        x1=-115.3,
+        y1=40.4,
+    )
+    pp = Pourpoint.from_geojson(record_path)
+    ds.rasterize_aoi(pp)
+
+    findings = diagnostics.run_health_checks(db, [ds], ['pourpoints'])
+
+    assert [f for f in findings if f['target'] == '55555:MT:USGS'] == []
 
 
 # --- doctor progress: per-item enumeration + live labels ---------------------

--- a/tests/snowdb/test_report_diagnostics.py
+++ b/tests/snowdb/test_report_diagnostics.py
@@ -1,5 +1,6 @@
 """Unit tests for the read-only report builders in snowdb.diagnostics."""
 
+import contextlib
 import shutil
 
 from datetime import date
@@ -341,6 +342,170 @@ def test_guard_wiring(guard_db, triplet, allow_partial, expectation):
             call()
 
 
+# --- pourpoints check: dedup + per-target roll-up ----------------------------
+
+
+def _write_empty_aoi(dataset, grid, triplet):
+    """Write an all-zero (but readable) AOI raster for ``triplet``."""
+    dataset._aoi_rasters.mkdir(parents=True, exist_ok=True)
+    write_cog(
+        dataset._aoi_rasters / f'{triplet.replace(":", "_")}.tif',
+        numpy.zeros((TILE, TILE), dtype=numpy.float32),
+        transform=grid.base_grid[0, 0].transform,
+        tile_size=TILE,
+        nodata=0,
+        tags={TILE_BBOX_TAG: '0 0 0 0'},
+        compute_stats=False,
+    )
+
+
+def test_pourpoints_check_reports_stray_raster_for_uncovered_basin(created_db, grid):
+    # An off-grid basin cannot be rasterized (`rasterize_aoi` refuses it; the batch
+    # path skips it), so an all-zero raster on disk is a stray artifact that should
+    # not exist -- a genuine anomaly, not a redundant symptom. It is reported
+    # (`empty AOI raster`) alongside the root-cause `no coverage`, rolled onto one
+    # row in coverage-then-health order.
+    db, ds = created_db
+    _write_basin(
+        db.pourpoint_records_path,
+        '300:MT:USGS',
+        x0=-110.0,
+        y0=44.9,
+        x1=-109.0,
+        y1=44.0,
+    )
+    _write_empty_aoi(ds, grid, '300:MT:USGS')
+
+    findings = diagnostics.run_health_checks(db, [ds], ['pourpoints'])
+
+    for_300 = [f for f in findings if f['target'] == '300:MT:USGS']
+    assert len(for_300) == 1
+    assert for_300[0]['issue'] == (
+        'no coverage; empty AOI raster (covers no in-grid cells: off-grid or masked)'
+    )
+
+
+def test_pourpoints_check_suppresses_no_raster_for_uncovered_basin(created_db):
+    # An off-grid basin cannot be rasterized (it has no in-grid pixels), so a
+    # missing raster is expected, not a fault. Only the root-cause `no coverage`
+    # is reported, not a redundant `no raster` -- for `partial coverage`, though,
+    # a raster is expected, so `no raster` still stands (see the roll-up test).
+    db, ds = created_db
+    _write_basin(
+        db.pourpoint_records_path,
+        '300:MT:USGS',
+        x0=-110.0,
+        y0=44.9,
+        x1=-109.0,
+        y1=44.0,
+    )
+
+    findings = diagnostics.run_health_checks(db, [ds], ['pourpoints'])
+
+    for_300 = [f for f in findings if f['target'] == '300:MT:USGS']
+    assert len(for_300) == 1
+    assert for_300[0]['issue'] == 'no coverage'
+
+
+def test_pourpoints_check_keeps_empty_aoi_for_covered_basin(created_db, grid):
+    # A covered basin whose raster is empty (e.g. entirely masked) is a genuine
+    # fault: `empty AOI raster` is reported here just as it is for the off-grid
+    # stray-raster case -- an all-zero raster always surfaces, covered or not.
+    db, ds = created_db
+    _write_basin(
+        db.pourpoint_records_path,
+        '100:MT:USGS',
+        x0=-119.9,
+        y0=44.9,
+        x1=-119.0,
+        y1=44.0,
+    )
+    _write_empty_aoi(ds, grid, '100:MT:USGS')
+
+    findings = diagnostics.run_health_checks(db, [ds], ['pourpoints'])
+
+    for_100 = [f for f in findings if f['target'] == '100:MT:USGS']
+    assert len(for_100) == 1
+    assert for_100[0]['issue'].startswith('empty AOI')
+
+
+def test_pourpoints_check_rolls_up_issues_for_one_target(created_db):
+    # A partial-coverage basin with no burned raster hits two pourpoint issues
+    # (`no raster` + `partial coverage`); doctor collapses them onto one row so a
+    # target never spans multiple lines. Emission order is coverage-report order.
+    db, ds = created_db
+    _write_basin(
+        db.pourpoint_records_path,
+        '200:MT:USGS',
+        x0=-120.5,
+        y0=44.9,
+        x1=-119.5,
+        y1=44.0,
+    )
+
+    findings = diagnostics.run_health_checks(db, [ds], ['pourpoints'])
+
+    for_200 = [f for f in findings if f['target'] == '200:MT:USGS']
+    assert len(for_200) == 1
+    assert for_200[0]['issue'] == 'no raster; partial coverage'
+
+
+# --- doctor progress: per-item enumeration + live labels ---------------------
+
+
+class _RecordingTask:
+    def __init__(self, rec):
+        self._rec = rec
+
+    def advance(self, n=1):
+        self._rec.advances += n
+
+    def describe(self, label):
+        self._rec.descriptions.append(label)
+
+
+class RecordingProgress:
+    """A ProgressReporter that records the total and every describe/advance."""
+
+    def __init__(self):
+        self.total = None
+        self.advances = 0
+        self.descriptions = []
+
+    @contextlib.contextmanager
+    def track(self, label, *, total=None):
+        self.total = total
+        yield _RecordingTask(self)
+
+
+def test_run_health_checks_reports_one_step_per_raster_and_check(
+    created_db,
+    pourpoint_geojson,
+):
+    # One increment per unit of work (per COG for grid, per AOI raster for
+    # pourpoints, plus the atomic declaration/inventory steps), all enumerated
+    # up front so `total` is exact, and each step announces what it is doing.
+    db, ds = created_db
+    write_swe_cog(ds, '20180427')  # one COG
+    shutil.copy(pourpoint_geojson, db.pourpoint_records_path / '12345_MT_USGS.geojson')
+    ds.rasterize_aoi(Pourpoint.from_geojson(pourpoint_geojson))  # one AOI raster
+
+    rec = RecordingProgress()
+    diagnostics.run_health_checks(db, [ds], ['grid', 'pourpoints'], progress=rec)
+
+    # grid: declaration + 1 COG; pourpoints: per-basin coverage (1) + orphan
+    # rasters + 1 AOI raster. Coverage is one step *per pourpoint*, so a large
+    # registry advances the bar instead of stalling on a single inventory step.
+    assert rec.total == 5
+    assert rec.advances == 5
+    assert len(rec.descriptions) == 5
+    assert rec.descriptions[0] == 'test grid: declaration'
+    assert rec.descriptions[1].startswith('test grid: 20180427/')
+    assert rec.descriptions[2] == 'test pourpoints: coverage 12345:MT:USGS'
+    assert rec.descriptions[3] == 'test pourpoints: orphan rasters'
+    assert rec.descriptions[4] == 'test pourpoints: AOI validation 12345:MT:USGS'
+
+
 # --- aoi-health --------------------------------------------------------------
 
 
@@ -482,6 +647,30 @@ def test_grid_validation_flags_shape_mismatch(dataset):
     issues = diagnostics.grid_validation_report(dataset)
 
     assert any('512x512' in issue and 'is 256x256' in issue for issue in issues)
+
+
+def test_grid_check_validates_every_cog_not_just_the_first(created_db):
+    # A clean COG on an early date and a drifted COG on a later date: the grid
+    # check opens *every* header, so the later drift is caught even though the
+    # first COG is fine (a first-COG-only sample would miss it). The finding names
+    # the specific file so it is actionable.
+    db, ds = created_db
+    write_swe_cog(ds, '20180101')  # aligned to the declared grid -> clean
+    bad_dir = ds._cogs / '20180201'
+    bad_dir.mkdir(parents=True)
+    write_cog(
+        bad_dir / f'{snodas_swe_name("20180201")}.tif',
+        numpy.zeros((256, 256), dtype=numpy.int16),
+        transform=ds.grid.base_grid.transform,
+        tile_size=TILE,
+    )
+
+    findings = diagnostics.run_health_checks(db, [ds], ['grid'])
+
+    grid = [f for f in findings if f['check'] == 'grid']
+    assert len(grid) == 1
+    assert grid[0]['target'] == f'20180201/{snodas_swe_name("20180201")}.tif'
+    assert '256x256' in grid[0]['issue']
 
 
 def test_grid_validation_flags_transform_mismatch(dataset):

--- a/tests/snowdb/test_report_diagnostics.py
+++ b/tests/snowdb/test_report_diagnostics.py
@@ -875,3 +875,88 @@ def test_grid_validation_flags_ingester_without_variables(tmp_path, spec):
     assert diagnostics.grid_validation_report(ds) == [
         'has an ingester but declares no variables',
     ]
+
+
+# --- grid check: zone layers + nodata mask -----------------------------------
+
+
+def test_grid_check_flags_misaligned_zone_layer(created_db):
+    # A present zone-layer file (terrain elevation) rewritten with a transform
+    # shifted a whole degree off the declared grid must be flagged, just like a
+    # misaligned COG -- same full-grid transform+shape comparison.
+    db, ds = created_db
+    write_terrain(ds)
+    write_landcover(ds)
+    path = ds.zones['terrain'].layer_path(ELEVATION)
+    with rasterio.open(path) as src:
+        array = src.read(1)
+        profile = src.profile
+    shifted = ds.grid.base_grid.transform
+    shifted = rasterio.Affine(
+        shifted.a,
+        shifted.b,
+        shifted.c + 1.0,
+        shifted.d,
+        shifted.e,
+        shifted.f,
+    )
+    write_cog(
+        path,
+        array,
+        transform=shifted,
+        crs=ds.grid_crs,
+        nodata=profile.get('nodata'),
+        tile_size=profile['blockxsize'],
+    )
+
+    findings = diagnostics.run_health_checks(db, [ds], ['grid'])
+
+    grid_findings = [f for f in findings if f['check'] == 'grid']
+    matching = [f for f in grid_findings if ELEVATION.filename in f['target']]
+    assert len(matching) == 1
+    assert 'declared grid transform' in matching[0]['issue']
+
+
+def test_grid_check_clean_for_aligned_zone_layers(created_db):
+    # Freshly built (on-grid) zone layers yield no grid-check findings.
+    db, ds = created_db
+    write_terrain(ds)
+    write_landcover(ds)
+
+    findings = diagnostics.run_health_checks(db, [ds], ['grid'])
+
+    assert [f for f in findings if f['check'] == 'grid'] == []
+
+
+def test_grid_check_flags_misaligned_nodata_mask(created_db, grid):
+    # A dataset with a configured nodata mask whose transform is shifted off the
+    # declared grid: the grid check must flag it, targeting `nodata-mask.tif`.
+    db, ds = created_db
+    mask_path = ds.path / 'nodata-mask.tif'
+    shifted = grid.base_grid.transform
+    shifted = rasterio.Affine(
+        shifted.a,
+        shifted.b,
+        shifted.c + 1.0,
+        shifted.d,
+        shifted.e,
+        shifted.f,
+    )
+    write_cog(
+        mask_path,
+        numpy.ones((512, 512), dtype=numpy.uint8),
+        transform=shifted,
+        crs=ds.grid_crs,
+        nodata=0,
+        tile_size=TILE,
+    )
+    ds.nodata_mask = mask_path
+    # nodata_mask_pair is a cached_property; the mask is used post-construction
+    # here so nothing else has forced it to cache the (now-stale) None state.
+
+    findings = diagnostics.run_health_checks(db, [ds], ['grid'])
+
+    grid_findings = [f for f in findings if f['check'] == 'grid']
+    matching = [f for f in grid_findings if f['target'] == 'nodata-mask.tif']
+    assert len(matching) == 1
+    assert 'declared grid transform' in matching[0]['issue']


### PR DESCRIPTION
- Fixes a misalignment between the built-in SNODAS grid and the published data files (nominal origin is not the same as that in the actual files). Resolves a ~40m offset error.
- Complete rebuild of the doctor command to better facilitate audits.