### PR TITLE
revert(snodas): restore the nominal grid registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Security
 
+## [v0.6.0] - 2026-07-24
+
+> **Live databases (SNODAS grid — reverts the v0.5.0 change):** the SNODAS grid
+> origin moves back from the product-header corner (`-124.73375 / 52.8745833`)
+> introduced in v0.5.0 to the rounded *nominal* corner (`-124.733333 / 52.875`).
+> Pixel size and dimensions (6935×3351) are unchanged. This is the grid the
+> project used before v0.5.0. As in v0.5.0, changing the built-in spec does
+> **not** move an existing dataset — its grid is persisted inline in
+> `data/<name>/dataset.json`, so that file's `grid.origin_x`/`origin_y` must be
+> restored to nominal (or the dataset re-created from the template). **If you
+> did not act on the v0.5.0 note** (never re-ingested onto the product-header
+> grid), your COGs, AOI rasters, zone layers, and nodata mask are still on the
+> nominal grid, so restoring `dataset.json` to nominal is the *only* step needed
+> and `doctor grid` goes green again. **If you did converge to the
+> product-header grid**, converge back to nominal the same way v0.5.0 described:
+> re-ingest the affected dates, rebuild AOI rasters with `pourpoint rasterize
+> --rebuild` (AOI provenance does not track the grid, so a plain converge will
+> not detect the shift), and regenerate the zone layers.
+
+### Changed
+
+- Reverted the SNODAS grid registration introduced in v0.5.0: the built-in spec
+  again declares the nominal corner (`-124.733333 / 52.875`) rather than the
+  product-header corner. See the live-databases note above.
+
 ## [v0.5.1] - 2026-07-24
 
 Internal refactor of the `doctor` health checks; no change to CLI behavior or
@@ -45,6 +70,10 @@ output.
   ['pourpoints'])`) in place of the removed helpers.
 
 ## [v0.5.0] - 2026-07-24
+
+> **⚠️ Reverted in v0.6.0 — do not follow the migration below.** The SNODAS
+> grid change described here was undone; the grid returns to the nominal corner.
+> See the v0.6.0 note above.
 
 > **Live databases (SNODAS grid change — action required):** the SNODAS grid
 > origin moves from the rounded *nominal* corner (`-124.733333 / 52.875`) to
@@ -647,7 +676,8 @@ output.
 
 Initial release 🎉
 
-[Unreleased]: https://github.com/PSU-CSAR/snowtool/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/PSU-CSAR/snowtool/compare/v0.6.0...HEAD
+[v0.6.0]: https://github.com/PSU-CSAR/snowtool/compare/v0.5.1...v0.6.0
 [v0.5.1]: https://github.com/PSU-CSAR/snowtool/compare/v0.5.0...v0.5.1
 [v0.5.0]: https://github.com/PSU-CSAR/snowtool/compare/v0.4.0...v0.5.0
 [v0.4.0]: https://github.com/PSU-CSAR/snowtool/compare/v0.3.0...v0.4.0

--- a/src/snowtool/snowdb/datasets/snodas.py
+++ b/src/snowtool/snowdb/datasets/snodas.py
@@ -507,13 +507,8 @@ SNODAS_VARIABLES = tuple(
 SNODAS_SPEC = DatasetSpec(
     name='snodas',
     grid_params=GridParams(
-        # SNODAS's product-header (native) corner, not the rounded nominal
-        # (-124.733333 / 52.875): the header registration is ~0.05 px (~40 m) SW
-        # of nominal and is what the source .Hdr files declare, so COGs ingested
-        # onto this grid (and the AOI rasters / zone layers burned on it) sit on
-        # the data's true lattice rather than a rounded one.
-        origin_x=-124.73375,
-        origin_y=52.8745833333333,
+        origin_x=-124.733333333333333,
+        origin_y=52.875000000000000,
         px_size=0.008333333333333,
         cols=6935,
         rows=3351,

--- a/tests/snowdb/test_grid.py
+++ b/tests/snowdb/test_grid.py
@@ -84,18 +84,6 @@ def test_tiling_shape() -> None:
     assert SNODAS_GRID.tile_size == (256, 256)
 
 
-def test_snodas_spec_declares_the_header_grid_registration() -> None:
-    # SNODAS COG headers carry the product's native corner (-124.73375 /
-    # 52.8745833) -- the rounded nominal (-124.733333 / 52.875) is ~0.05 px
-    # (~40 m) NE of it. The spec declares the header registration so ingested
-    # COGs sit on the source's true lattice (and AOI rasters/zone layers, all
-    # burned on this grid, agree with it). Pixel size and dimensions are unchanged.
-    assert _GP.origin_x == -124.73375
-    assert _GP.origin_y == pytest.approx(52.8745833333333, abs=1e-10)
-    assert _GP.px_size == 0.008333333333333
-    assert (_GP.cols, _GP.rows) == (6935, 3351)
-
-
 def test_point_to_tile_matches_pixel_floor_div() -> None:
     pt = Point(-115.087346, 47.301864)
     cell = SNODAS_GRID.base_grid.point_to_cell(pt)


### PR DESCRIPTION
Revert the SNODAS grid origin from the product-header corner (-124.73375 / 52.8745833, adopted in v0.5.0) back to the rounded nominal corner (-124.733333 / 52.875) -- the grid the project used before v0.5.0. Pixel size and dimensions (6935x3351) are unchanged.

Restores the template spec and removes the header-grid assertion that was added alongside the change. CHANGELOG: adds a v0.6.0 section with a live-databases revert note and flags the now-superseded v0.5.0 migration note as reverted.

The shipped and live nodata masks were never regenerated for the v0.5.0 change (both remained on the nominal grid), so reverting the declared grid restores consistency rather than requiring a mask rebuild.